### PR TITLE
KOGITO-4520: Design and adopt a strategy for auto/manual resize the Table columns in the Boxed Expression Editor

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/package.json
+++ b/kie-wb-common-react/boxed-expression-editor/package.json
@@ -70,10 +70,12 @@
     "@patternfly/react-styles": "^4.7.8",
     "@patternfly/react-table": "^4.19.45",
     "@types/react-resizable": "^1.7.2",
+    "@types/uuid": "^8.3.0",
     "lodash": "^4.17.20",
     "react-id-generator": "^3.0.1",
     "react-resizable": "^1.11.0",
-    "react-table": "^7.6.2"
+    "react-table": "^7.6.2",
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "react": "16.12.0",

--- a/kie-wb-common-react/boxed-expression-editor/showcase/public/index.html
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/public/index.html
@@ -24,11 +24,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="./favicon.png">
   <base href="/">
+  <!-- Issue workaround for React v16. -->
+  <script>
+    // See https://github.com/facebook/react/issues/20829#issuecomment-802088260
+    if (!crossOriginIsolated) SharedArrayBuffer = ArrayBuffer;
+  </script>
 </head>
 
 <body>
-<noscript>Enabling JavaScript is required to run this app.</noscript>
-<div id="root"></div>
+  <noscript>Enabling JavaScript is required to run this app.</noscript>
+  <div id="root"></div>
 </body>
 
 </html>

--- a/kie-wb-common-react/boxed-expression-editor/src/@types/react-table.d.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/@types/react-table.d.ts
@@ -62,10 +62,6 @@ declare module "react-table" {
     dataType: DataType;
     /** When resizable, this function returns the resizer props  */
     getResizerProps: (props?: Partial<TableResizerProps>) => TableResizerProps;
-    /** It tells whether column can be resized or not */
-    canResize: boolean;
-    /** It tells whether column can be resized on each cell of such column */
-    canResizeOnCell?: boolean;
     /** It tells whether column is of type counter or not */
     isCountColumn: boolean;
     /** Disabling table handler on the header of this column */

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/__mocks__/ReactWithSupervisor.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/__mocks__/ReactWithSupervisor.ts
@@ -14,23 +14,20 @@
  * limitations under the License.
  */
 
-import "./Resizer.css";
-import * as React from "react";
-import { applyDOMSupervisor } from "./dom";
-import { useEffect, useContext } from "react";
-import { BoxedExpressionGlobalContext } from "../../context";
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
 
-export interface ResizerSupervisorProps {
-  children?: React.ReactElement;
-}
+  function useContext<T>(context: React.Context<T>) {
+    return {
+      ...actualReact.useContext(context),
+      ...{
+        setSupervisorHash: (hash: number) => hash,
+      },
+    };
+  }
 
-export const ResizerSupervisor: React.FunctionComponent<ResizerSupervisorProps> = ({ children }) => {
-  const { supervisorHash } = useContext(BoxedExpressionGlobalContext);
-
-  useEffect(() => {
-    const id = setTimeout(applyDOMSupervisor, 0);
-    return () => clearTimeout(id);
-  }, [supervisorHash]);
-
-  return <>{children}</>;
-};
+  return {
+    ...actualReact,
+    useContext: useContext,
+  };
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
@@ -2,38 +2,36 @@
 
 exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor component 1`] = `
 <div>
-  <div>
+  <div
+    class="boxed-expression-editor"
+  >
     <div
-      class="boxed-expression-editor"
+      class="expression-container"
     >
       <div
-        class="expression-container"
+        class="expression-name-and-logic-type"
+      >
+        <span
+          class="expression-title"
+        >
+          Expression Name
+        </span>
+        <span
+          class="expression-type"
+        >
+          (
+          &lt;Undefined&gt;
+          )
+        </span>
+      </div>
+      <div
+        class="expression-container-box"
+        data-ouia-component-id="expression-container"
       >
         <div
-          class="expression-name-and-logic-type"
+          class="logic-type-selector no-table-context-menu logic-type-not-present"
         >
-          <span
-            class="expression-title"
-          >
-            Expression Name
-          </span>
-          <span
-            class="expression-type"
-          >
-            (
-            &lt;Undefined&gt;
-            )
-          </span>
-        </div>
-        <div
-          class="expression-container-box"
-          data-ouia-component-id="expression-container"
-        >
-          <div
-            class="logic-type-selector no-table-context-menu logic-type-not-present"
-          >
-            Select expression
-          </div>
+          Select expression
         </div>
       </div>
     </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/BoxedExpressionEditor/__snapshots__/BoxedExpressionEditor.test.tsx.snap
@@ -2,36 +2,38 @@
 
 exports[`BoxedExpressionEditor tests should render BoxedExpressionEditor component 1`] = `
 <div>
-  <div
-    class="boxed-expression-editor"
-  >
+  <div>
     <div
-      class="expression-container"
+      class="boxed-expression-editor"
     >
       <div
-        class="expression-name-and-logic-type"
-      >
-        <span
-          class="expression-title"
-        >
-          Expression Name
-        </span>
-        <span
-          class="expression-type"
-        >
-          (
-          &lt;Undefined&gt;
-          )
-        </span>
-      </div>
-      <div
-        class="expression-container-box"
-        data-ouia-component-id="expression-container"
+        class="expression-container"
       >
         <div
-          class="logic-type-selector no-table-context-menu logic-type-not-present"
+          class="expression-name-and-logic-type"
         >
-          Select expression
+          <span
+            class="expression-title"
+          >
+            Expression Name
+          </span>
+          <span
+            class="expression-type"
+          >
+            (
+            &lt;Undefined&gt;
+            )
+          </span>
+        </div>
+        <div
+          class="expression-container-box"
+          data-ouia-component-id="expression-container"
+        >
+          <div
+            class="logic-type-selector no-table-context-menu logic-type-not-present"
+          >
+            Select expression
+          </div>
         </div>
       </div>
     </div>

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import "../../__mocks__/ReactWithSupervisor";
 import { render } from "@testing-library/react";
 import {
   checkEntryContent,
@@ -109,21 +110,3 @@ jest.mock("../../../api", () => ({
   ...(jest.requireActual("../../../api") as Record<string, unknown>),
   getHandlerConfiguration: jest.fn(),
 }));
-
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  function useContext<T>(context: React.Context<T>) {
-    return {
-      ...actualReact.useContext(context),
-      ...{
-        setSupervisorHash: (hash: number) => hash,
-      },
-    };
-  }
-
-  return {
-    ...actualReact,
-    useContext: useContext,
-  };
-});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ContextExpression/ContextExpression.test.tsx
@@ -26,11 +26,6 @@ import { ContextExpression } from "../../../components/ContextExpression";
 import * as React from "react";
 import { DataType, LogicType } from "../../../api";
 
-jest.mock("../../../api", () => ({
-  ...(jest.requireActual("../../../api") as Record<string, unknown>),
-  getHandlerConfiguration: jest.fn(),
-}));
-
 describe("ContextExpression tests", () => {
   const name = "contextName";
   const dataType = DataType.Boolean;
@@ -108,4 +103,27 @@ describe("ContextExpression tests", () => {
     checkEntryStyle(contextEntry(container, 2), "logic-type-not-present");
     checkEntryStyle(contextEntry(container, 3), "logic-type-not-present");
   });
+});
+
+jest.mock("../../../api", () => ({
+  ...(jest.requireActual("../../../api") as Record<string, unknown>),
+  getHandlerConfiguration: jest.fn(),
+}));
+
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
+
+  function useContext<T>(context: React.Context<T>) {
+    return {
+      ...actualReact.useContext(context),
+      ...{
+        setSupervisorHash: (hash: number) => hash,
+      },
+    };
+  }
+
+  return {
+    ...actualReact,
+    useContext: useContext,
+  };
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import "../../__mocks__/ReactWithSupervisor";
 import { fireEvent, render } from "@testing-library/react";
 import {
   activateSelector,
@@ -378,21 +379,3 @@ describe("FunctionExpression tests", () => {
 });
 
 jest.useFakeTimers();
-
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  function useContext<T>(context: React.Context<T>) {
-    return {
-      ...actualReact.useContext(context),
-      ...{
-        setSupervisorHash: (hash: number) => hash,
-      },
-    };
-  }
-
-  return {
-    ...actualReact,
-    useContext: useContext,
-  };
-});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
@@ -27,8 +27,6 @@ import { DataType, EntryInfo, FunctionKind, FunctionProps, LogicType } from "../
 import { act } from "react-dom/test-utils";
 import * as _ from "lodash";
 
-jest.useFakeTimers();
-
 describe("FunctionExpression tests", () => {
   test("should show a table with two levels visible header, with one row and one column", () => {
     const { container } = render(
@@ -82,6 +80,7 @@ describe("FunctionExpression tests", () => {
       functionKind: "FEEL",
       logicType: "Function",
       name: "p-1",
+      parametersWidth: 370,
       uid: undefined,
     });
   });
@@ -242,6 +241,7 @@ describe("FunctionExpression tests", () => {
         functionKind: "FEEL",
         logicType: "Function",
         name: "p-1",
+        parametersWidth: 370,
         uid: undefined,
       });
     }
@@ -375,4 +375,24 @@ describe("FunctionExpression tests", () => {
       await jest.runAllTimers();
     });
   }
+});
+
+jest.useFakeTimers();
+
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
+
+  function useContext<T>(context: React.Context<T>) {
+    return {
+      ...actualReact.useContext(context),
+      ...{
+        setSupervisorHash: (hash: number) => hash,
+      },
+    };
+  }
+
+  return {
+    ...actualReact,
+    useContext: useContext,
+  };
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/InvocationExpression/InvocationExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/InvocationExpression/InvocationExpression.test.tsx
@@ -20,11 +20,6 @@ import { DataType, LogicType } from "../../../api";
 import * as React from "react";
 import { InvocationExpression } from "../../../components/InvocationExpression";
 
-jest.mock("../../../api", () => ({
-  ...(jest.requireActual("../../../api") as Record<string, unknown>),
-  getHandlerConfiguration: jest.fn(),
-}));
-
 describe("InvocationExpression tests", () => {
   test("should show a table with two levels visible header, with one row and two columns", () => {
     const { container } = render(
@@ -96,4 +91,27 @@ describe("InvocationExpression tests", () => {
     checkEntryContent(contextEntry(container, 1), firstEntry.entryInfo);
     checkEntryContent(contextEntry(container, 2), secondEntry.entryInfo);
   });
+});
+
+jest.mock("../../../api", () => ({
+  ...(jest.requireActual("../../../api") as Record<string, unknown>),
+  getHandlerConfiguration: jest.fn(),
+}));
+
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
+
+  function useContext<T>(context: React.Context<T>) {
+    return {
+      ...actualReact.useContext(context),
+      ...{
+        setSupervisorHash: (hash: number) => hash,
+      },
+    };
+  }
+
+  return {
+    ...actualReact,
+    useContext: useContext,
+  };
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/InvocationExpression/InvocationExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/InvocationExpression/InvocationExpression.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import "../../__mocks__/ReactWithSupervisor";
 import { render } from "@testing-library/react";
 import { checkEntryContent, contextEntry, usingTestingBoxedExpressionI18nContext } from "../test-utils";
 import { DataType, LogicType } from "../../../api";
@@ -97,21 +98,3 @@ jest.mock("../../../api", () => ({
   ...(jest.requireActual("../../../api") as Record<string, unknown>),
   getHandlerConfiguration: jest.fn(),
 }));
-
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  function useContext<T>(context: React.Context<T>) {
-    return {
-      ...actualReact.useContext(context),
-      ...{
-        setSupervisorHash: (hash: number) => hash,
-      },
-    };
-  }
-
-  return {
-    ...actualReact,
-    useContext: useContext,
-  };
-});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ListExpression/ListExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ListExpression/ListExpression.test.tsx
@@ -63,3 +63,21 @@ describe("ListExpression tests", () => {
     ).toBeEmpty();
   });
 });
+
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
+
+  function useContext<T>(context: React.Context<T>) {
+    return {
+      ...actualReact.useContext(context),
+      ...{
+        setSupervisorHash: (hash: number) => hash,
+      },
+    };
+  }
+
+  return {
+    ...actualReact,
+    useContext: useContext,
+  };
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ListExpression/ListExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/ListExpression/ListExpression.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import "../../__mocks__/ReactWithSupervisor";
 import { render } from "@testing-library/react";
 import { usingTestingBoxedExpressionI18nContext } from "../test-utils";
 import { LogicType } from "../../../api";
@@ -62,22 +63,4 @@ describe("ListExpression tests", () => {
       )
     ).toBeEmpty();
   });
-});
-
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  function useContext<T>(context: React.Context<T>) {
-    return {
-      ...actualReact.useContext(context),
-      ...{
-        setSupervisorHash: (hash: number) => hash,
-      },
-    };
-  }
-
-  return {
-    ...actualReact,
-    useContext: useContext,
-  };
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LogicTypeSelector/LogicTypeSelector.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LogicTypeSelector/LogicTypeSelector.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import "../../__mocks__/ReactWithSupervisor";
 import { DataType, LogicType } from "../../../api";
 import { fireEvent, render } from "@testing-library/react";
 import { flushPromises, usingTestingBoxedExpressionI18nContext } from "../test-utils";
@@ -121,21 +122,3 @@ const triggerContextMenu = async (container: HTMLElement, selector: string) => {
 };
 
 jest.useFakeTimers();
-
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-
-  function useContext<T>(context: React.Context<T>) {
-    return {
-      ...actualReact.useContext(context),
-      ...{
-        setSupervisorHash: (hash: number) => hash,
-      },
-    };
-  }
-
-  return {
-    ...actualReact,
-    useContext: useContext,
-  };
-});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LogicTypeSelector/LogicTypeSelector.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/LogicTypeSelector/LogicTypeSelector.test.tsx
@@ -22,8 +22,6 @@ import * as React from "react";
 import { LogicTypeSelector } from "../../../components/LogicTypeSelector";
 import * as _ from "lodash";
 
-jest.useFakeTimers();
-
 describe("LogicTypeSelector tests", () => {
   test("should have the clear action disabled on startup", async () => {
     const expression = { name: "Test", dataType: DataType.Undefined };
@@ -121,3 +119,23 @@ const triggerContextMenu = async (container: HTMLElement, selector: string) => {
     jest.runAllTimers();
   });
 };
+
+jest.useFakeTimers();
+
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
+
+  function useContext<T>(context: React.Context<T>) {
+    return {
+      ...actualReact.useContext(context),
+      ...{
+        setSupervisorHash: (hash: number) => hash,
+      },
+    };
+  }
+
+  return {
+    ...actualReact,
+    useContext: useContext,
+  };
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/Resizer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/Resizer.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import "../../__mocks__/ReactWithSupervisor";
 import { fireEvent, render, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { Resizer } from "src/components/Resizer";
@@ -76,15 +77,3 @@ function renderTable() {
     </>
   ).container;
 }
-
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-  return {
-    ...actualReact,
-    useContext: () => {
-      return {
-        setSupervisorHash: (hash: number) => hash,
-      };
-    },
-  };
-});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/Resizer.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/Resizer.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { Resizer } from "src/components/Resizer";
+
+describe("Resizer", () => {
+  describe("when users drag the dragabble element", () => {
+    it("resizes the element", async () => {
+      const container = renderTable();
+      const dragabble = container.querySelector(".col-2-3 .react-resizable .pf-c-drawer")!;
+      const resizable = container.querySelectorAll(".react-resizable")!;
+      const getWidth = (e: Node) => (e as HTMLElement).style.width;
+
+      fireEvent.mouseDown(dragabble);
+      fireEvent.mouseMove(dragabble, { clientX: 150 });
+      fireEvent.mouseUp(dragabble);
+
+      await waitFor(() => {
+        expect(getWidth(resizable.item(0))).toBe("250px");
+        expect(getWidth(resizable.item(1))).toBe("250px");
+        expect(getWidth(resizable.item(2))).toBe("350px");
+        expect(getWidth(resizable.item(3))).toBe("250px");
+        expect(getWidth(resizable.item(4))).toBe("250px");
+        expect(getWidth(resizable.item(5))).toBe("350px");
+      });
+    });
+  });
+});
+
+function renderTable() {
+  return render(
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th className="col-1-1">
+              <Resizer width={250}></Resizer>
+            </th>
+            <th className="col-1-2">
+              <Resizer width={250}></Resizer>
+            </th>
+            <th className="col-1-3">
+              <Resizer width={250}></Resizer>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="col-2-1">
+              <Resizer width={250}></Resizer>
+            </td>
+            <td className="col-2-2">
+              <Resizer width={250}></Resizer>
+            </td>
+            <td className="col-2-3">
+              <Resizer width={250}></Resizer>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </>
+  ).container;
+}
+
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
+  return {
+    ...actualReact,
+    useContext: () => {
+      return {
+        setSupervisorHash: (hash: number) => hash,
+      };
+    },
+  };
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/dom/Cell.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/dom/Cell.test.tsx
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Cell, CELL_CSS_SELCTOR } from "src/components/Resizer/dom";
+import { Resizer } from "src/components/Resizer";
+import { render } from "@testing-library/react";
+import { usingTestingBoxedExpressionI18nContext } from "../../test-utils";
+import * as React from "react";
+import { ContextExpression } from "src/components/ContextExpression";
+import { ContextProps } from "src/api";
+import { act } from "react-dom/test-utils";
+
+let cell: Cell;
+let element: HTMLElement;
+let container: Element;
+
+describe("Cell", () => {
+  beforeAll(() => {
+    document.dispatchEvent = jest.fn();
+  });
+
+  describe("getId", () => {
+    beforeEach(createLiteral);
+    it("returns the id present in the cell element", () => {
+      expect(cell.getId()).toBe("uuid-0000-1111-2222-3333");
+    });
+  });
+
+  describe("getRect", () => {
+    beforeEach(createLiteral);
+    it("returns the rect from the cell element", () => {
+      expect(cell.getRect()).toEqual(element.getBoundingClientRect());
+    });
+  });
+
+  describe("setWidth", () => {
+    beforeEach(createLiteral);
+
+    it("set the width in the element", () => {
+      act(() => cell.setWidth(150));
+      expect(element.style.width).toEqual("150px");
+      expect(document.dispatchEvent).toBeCalled();
+    });
+
+    it("set the width in the element considering the minimum value", () => {
+      act(() => cell.setWidth(80));
+      expect(element.style.width).toEqual("150px");
+      expect(document.dispatchEvent).toBeCalled();
+    });
+  });
+
+  describe("refreshWidthAsParent", () => {
+    it("set the width as parent", () => {
+      act(() => {
+        createContext();
+
+        const elements = container.querySelectorAll(CELL_CSS_SELCTOR);
+        const child1 = new Cell(elements.item(1) as HTMLElement, [], 1);
+        const child2 = new Cell(elements.item(2) as HTMLElement, [], 1);
+
+        element = elements.item(3) as HTMLElement;
+
+        cell = new Cell(element, [child1, child2], 0);
+
+        cell.refreshWidthAsParent();
+      });
+      expect(element.style.width).toBe("713px");
+    });
+  });
+
+  describe("refreshWidthAsLastColumn", () => {
+    it("set the width as the last column", () => {
+      act(() => {
+        createContext();
+
+        const elements = container.querySelectorAll(CELL_CSS_SELCTOR);
+        const child1 = new Cell(elements.item(0) as HTMLElement, [], 1);
+        const child2 = new Cell(elements.item(1) as HTMLElement, [], 1);
+
+        element = elements.item(2) as HTMLElement;
+        cell = new Cell(element, [child1, child2], 0);
+
+        cell.refreshWidthAsLastColumn();
+      });
+      expect(element.style.width).toBe("1468px");
+    });
+
+    it("does not change the width when it is not the last column", () => {
+      act(() => {
+        createLiteral();
+        cell.refreshWidthAsLastColumn();
+      });
+      expect(element.style.width).toBe("250px");
+    });
+  });
+
+  describe("isLastColumn", () => {
+    it("returns true when the literal expression lives in the last column", () => {
+      act(renderLiteralAtLastColumn);
+
+      expect(cell.isLastColumn()).toBeTruthy();
+    });
+
+    it("returns false when the literal expression does not live in the last column", () => {
+      act(renderLiteralAtRegularColumn);
+      expect(cell.isLastColumn()).toBeFalsy();
+    });
+  });
+});
+
+function renderLiteralAtRegularColumn() {
+  container = render(
+    usingTestingBoxedExpressionI18nContext(
+      <>
+        <table>
+          <tbody>
+            <tr>
+              <td></td>
+              <td>
+                <Resizer width={250}></Resizer>
+              </td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </>
+    ).wrapper
+  ).container;
+  element = container.querySelector(CELL_CSS_SELCTOR) as HTMLElement;
+  cell = new Cell(element, [], 0);
+}
+
+function renderLiteralAtLastColumn() {
+  container = render(
+    usingTestingBoxedExpressionI18nContext(
+      <>
+        <table>
+          <tbody>
+            <tr>
+              <td></td>
+              <td></td>
+              <td>
+                <Resizer width={250}></Resizer>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </>
+    ).wrapper
+  ).container;
+  element = container.querySelector(CELL_CSS_SELCTOR) as HTMLElement;
+  cell = new Cell(element, [], 0);
+}
+
+function createLiteral() {
+  container = render(<Resizer width={250}></Resizer>).container;
+  element = container.querySelector(CELL_CSS_SELCTOR) as HTMLElement;
+  cell = new Cell(element, [], 0);
+}
+
+function createContext() {
+  container = render(
+    usingTestingBoxedExpressionI18nContext(
+      <ContextExpression
+        {...(({
+          uid: "id1",
+          logicType: "Context",
+          name: "Expression Name",
+          dataType: "<Undefined>",
+          contextEntries: [
+            {
+              entryInfo: {
+                name: "ContextEntry-1",
+                dataType: "<Undefined>",
+              },
+              entryExpression: {
+                uid: "id2",
+                logicType: "Context",
+                contextEntries: [
+                  {
+                    entryInfo: {
+                      name: "ContextEntry-1",
+                      dataType: "<Undefined>",
+                    },
+                    entryExpression: {
+                      uid: "id4",
+                      logicType: "Context",
+                      contextEntries: [
+                        {
+                          entryInfo: {
+                            name: "ContextEntry-1",
+                            dataType: "<Undefined>",
+                          },
+                          entryExpression: {},
+                          editInfoPopoverLabel: "Edit Context Entry",
+                        },
+                      ],
+                      result: {
+                        uid: "id7",
+                      },
+                      entryInfoWidth: 257,
+                      entryExpressionWidth: 370,
+                    },
+                    editInfoPopoverLabel: "Edit Context Entry",
+                  },
+                ],
+                result: {
+                  uid: "id5",
+                },
+                entryInfoWidth: 713,
+                entryExpressionWidth: 691,
+              },
+              editInfoPopoverLabel: "Edit Context Entry",
+            },
+          ],
+          result: {
+            uid: "id3",
+          },
+          entryInfoWidth: 150,
+          entryExpressionWidth: 1468,
+        } as unknown) as ContextProps)}
+      />
+    ).wrapper
+  ).container;
+}
+
+jest.mock("uuid", () => {
+  return { v4: () => "0000-1111-2222-3333" };
+});
+
+jest.mock("react", () => {
+  const actualReact = jest.requireActual("react");
+  return {
+    ...actualReact,
+    useContext: () => {
+      return {
+        setSupervisorHash: (hash: number) => hash,
+        i18n: {
+          editContextEntry: "",
+          rowOperations: {},
+        },
+      };
+    },
+  };
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/dom/Cell.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/dom/Cell.test.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Cell, CELL_CSS_SELCTOR } from "src/components/Resizer/dom";
+import "../../../__mocks__/ReactWithSupervisor";
+import { Cell, CELL_CSS_SELECTOR } from "src/components/Resizer/dom";
 import { Resizer } from "src/components/Resizer";
 import { render } from "@testing-library/react";
 import { usingTestingBoxedExpressionI18nContext } from "../../test-utils";
@@ -67,7 +68,7 @@ describe("Cell", () => {
       act(() => {
         createContext();
 
-        const elements = container.querySelectorAll(CELL_CSS_SELCTOR);
+        const elements = container.querySelectorAll(CELL_CSS_SELECTOR);
         const child1 = new Cell(elements.item(1) as HTMLElement, [], 1);
         const child2 = new Cell(elements.item(2) as HTMLElement, [], 1);
 
@@ -86,7 +87,7 @@ describe("Cell", () => {
       act(() => {
         createContext();
 
-        const elements = container.querySelectorAll(CELL_CSS_SELCTOR);
+        const elements = container.querySelectorAll(CELL_CSS_SELECTOR);
         const child1 = new Cell(elements.item(0) as HTMLElement, [], 1);
         const child2 = new Cell(elements.item(1) as HTMLElement, [], 1);
 
@@ -139,7 +140,7 @@ function renderLiteralAtRegularColumn() {
       </>
     ).wrapper
   ).container;
-  element = container.querySelector(CELL_CSS_SELCTOR) as HTMLElement;
+  element = container.querySelector(CELL_CSS_SELECTOR) as HTMLElement;
   cell = new Cell(element, [], 0);
 }
 
@@ -161,13 +162,13 @@ function renderLiteralAtLastColumn() {
       </>
     ).wrapper
   ).container;
-  element = container.querySelector(CELL_CSS_SELCTOR) as HTMLElement;
+  element = container.querySelector(CELL_CSS_SELECTOR) as HTMLElement;
   cell = new Cell(element, [], 0);
 }
 
 function createLiteral() {
   container = render(<Resizer width={250}></Resizer>).container;
-  element = container.querySelector(CELL_CSS_SELCTOR) as HTMLElement;
+  element = container.querySelector(CELL_CSS_SELECTOR) as HTMLElement;
   cell = new Cell(element, [], 0);
 }
 
@@ -239,20 +240,4 @@ function createContext() {
 
 jest.mock("uuid", () => {
   return { v4: () => "0000-1111-2222-3333" };
-});
-
-jest.mock("react", () => {
-  const actualReact = jest.requireActual("react");
-  return {
-    ...actualReact,
-    useContext: () => {
-      return {
-        setSupervisorHash: (hash: number) => hash,
-        i18n: {
-          editContextEntry: "",
-          rowOperations: {},
-        },
-      };
-    },
-  };
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/dom/DOMSession.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/dom/DOMSession.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { Cell, DOMSession } from "src/components/Resizer/dom";
+
+describe("DOMSession", () => {
+  let session: DOMSession;
+  let cells: Cell[];
+
+  beforeEach(() => {
+    render(
+      <>
+        <div data-test-id="cell-0" className="react-resizable">
+          <div data-test-id="cell-1" className="react-resizable">
+            <div data-test-id="cell-2" className="react-resizable"></div>
+            <div data-test-id="cell-3" className="react-resizable"></div>
+          </div>
+          <div data-test-id="cell-4" className="react-resizable"></div>
+        </div>
+        <div data-test-id="cell-5" className="react-resizable"></div>
+        <div data-test-id="cell-6" className="react-resizable"></div>
+      </>
+    );
+
+    session = new DOMSession();
+  });
+
+  describe("getCells", () => {
+    beforeEach(() => {
+      cells = session.getCells();
+    });
+
+    it("returns the cells with depth information", () => {
+      expect(cells[4].element.dataset.testId).toBe("cell-0");
+      expect(cells[4].depth).toBe(0);
+      expect(cells[5].element.dataset.testId).toBe("cell-5");
+      expect(cells[5].depth).toBe(0);
+      expect(cells[6].element.dataset.testId).toBe("cell-6");
+      expect(cells[6].depth).toBe(0);
+
+      expect(cells[2].element.dataset.testId).toBe("cell-1");
+      expect(cells[2].depth).toBe(1);
+      expect(cells[3].element.dataset.testId).toBe("cell-4");
+      expect(cells[3].depth).toBe(1);
+
+      expect(cells[0].element.dataset.testId).toBe("cell-2");
+      expect(cells[0].depth).toBe(2);
+      expect(cells[1].element.dataset.testId).toBe("cell-3");
+      expect(cells[1].depth).toBe(2);
+    });
+
+    it("returns the cells with children", () => {
+      expect(cells[0].children).toHaveLength(0);
+      expect(cells[1].children).toHaveLength(0);
+      expect(cells[2].children).toHaveLength(2);
+      expect(cells[3].children).toHaveLength(0);
+      expect(cells[4].children).toHaveLength(2);
+      expect(cells[5].children).toHaveLength(0);
+      expect(cells[6].children).toHaveLength(0);
+    });
+  });
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/dom/ResizerSupervisorDOM.test.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/Resizer/dom/ResizerSupervisorDOM.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { applyDOMSupervisor, Cell } from "src/components/Resizer/dom";
+
+const fakeCells = [fakeCell(0), fakeCell(2), fakeCell(4), fakeCell(8)];
+
+describe("ResizerSupervisorDOM", () => {
+  describe("applyDOMSupervisor", () => {
+    beforeEach(() => {
+      applyDOMSupervisor();
+    });
+
+    it("refreshes cell widths as parents", () => {
+      expect(fakeCells[0].spyRefreshWidthAsParent).toBeCalled();
+      expect(fakeCells[1].spyRefreshWidthAsParent).toBeCalled();
+      expect(fakeCells[2].spyRefreshWidthAsParent).toBeCalled();
+      expect(fakeCells[3].spyRefreshWidthAsParent).toBeCalled();
+    });
+
+    it("refreshes cell widths as last column", () => {
+      expect(fakeCells[0].spyRefreshWidthAsLastColumn).toBeCalled();
+      expect(fakeCells[1].spyRefreshWidthAsLastColumn).toBeCalled();
+      expect(fakeCells[2].spyRefreshWidthAsLastColumn).toBeCalled();
+      expect(fakeCells[3].spyRefreshWidthAsLastColumn).toBeCalled();
+    });
+  });
+});
+
+jest.mock("src/components/Resizer/dom", () => {
+  const actualResizerDOM = jest.requireActual("src/components/Resizer/dom");
+  return {
+    ...actualResizerDOM,
+    DOMSession: jest.fn(() => ({
+      getCells: () => fakeCells.map((c) => c.cell),
+    })),
+    Cell: jest.fn(() => ({
+      refreshWidthAsParent: () => ({}),
+      refreshWidthAsLastColumn: () => ({}),
+    })),
+  };
+});
+
+function fakeCell(depth: number) {
+  const cell = new Cell({} as HTMLElement, [], depth);
+  const spyRefreshWidthAsParent = jest.spyOn(cell, "refreshWidthAsParent");
+  const spyRefreshWidthAsLastColumn = jest.spyOn(cell, "refreshWidthAsLastColumn");
+  return { cell, spyRefreshWidthAsParent, spyRefreshWidthAsLastColumn };
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/Table.ts
@@ -105,6 +105,8 @@ export interface Column {
   dataType: DataType;
   /** Column width */
   width?: string | number;
+  /** Set column width */
+  setWidth?: (width: string | number) => void;
 }
 
 export type Columns = Column[];

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.css
@@ -23,11 +23,14 @@
   text-align: left;
 }
 
-.boxed-expression-editor *, .boxed-expression-editor *:after, .boxed-expression-editor *:before {
+.boxed-expression-editor *,
+.boxed-expression-editor *:after,
+.boxed-expression-editor *:before {
   box-sizing: border-box;
 }
 
-.boxed-expression-editor a, .boxed-expression-editor button {
+.boxed-expression-editor a,
+.boxed-expression-editor button {
   cursor: pointer;
 }
 
@@ -36,8 +39,13 @@
   border-collapse: collapse;
 }
 
+.boxed-expression-editor textarea {
+  outline: none;
+}
+
 .boxed-expression-editor .pf-c-menu__group-title {
-  padding: var(--pf-c-menu__group-title--PaddingTop) var(--pf-c-menu__group-title--PaddingRight) var(--pf-c-menu__group-title--PaddingBottom) var(--pf-c-menu__group-title--PaddingLeft);
+  padding: var(--pf-c-menu__group-title--PaddingTop) var(--pf-c-menu__group-title--PaddingRight)
+    var(--pf-c-menu__group-title--PaddingBottom) var(--pf-c-menu__group-title--PaddingLeft);
   font-weight: var(--pf-c-menu__group-title--FontWeight);
   color: var(--pf-c-menu__group-title--Color);
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -15,12 +15,13 @@
  */
 
 import * as React from "react";
-import { useRef, useState } from "react";
+import { useRef, useState, useMemo } from "react";
 import "@patternfly/react-core/dist/styles/base-no-reset.css";
 import "@patternfly/react-styles/css/components/Drawer/drawer.css";
 import "./BoxedExpressionEditor.css";
 import { I18nDictionariesProvider } from "@kogito-tooling/i18n/dist/react-components";
 import { ExpressionContainer, ExpressionContainerProps } from "../ExpressionContainer";
+import { ResizerSupervisor, hashfy } from "../Resizer";
 import {
   boxedExpressionEditorDictionaries,
   BoxedExpressionEditorI18nContext,
@@ -39,22 +40,35 @@ const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element 
 ) => {
   const [currentlyOpenedHandlerCallback, setCurrentlyOpenedHandlerCallback] = useState(() => _.identity);
   const boxedExpressionEditorRef = useRef<HTMLDivElement>(null);
+  const [supervisorHash, setSupervisorHash] = useState(hashfy(props.expressionDefinition));
 
-  return (
-    <I18nDictionariesProvider
-      defaults={boxedExpressionEditorI18nDefaults}
-      dictionaries={boxedExpressionEditorDictionaries}
-      initialLocale={navigator.language}
-      ctx={BoxedExpressionEditorI18nContext}
-    >
-      <BoxedExpressionGlobalContext.Provider
-        value={{ boxedExpressionEditorRef, currentlyOpenedHandlerCallback, setCurrentlyOpenedHandlerCallback }}
+  return useMemo(
+    () => (
+      <I18nDictionariesProvider
+        defaults={boxedExpressionEditorI18nDefaults}
+        dictionaries={boxedExpressionEditorDictionaries}
+        initialLocale={navigator.language}
+        ctx={BoxedExpressionEditorI18nContext}
       >
-        <div className="boxed-expression-editor" ref={boxedExpressionEditorRef}>
-          <ExpressionContainer {...props.expressionDefinition} />
-        </div>
-      </BoxedExpressionGlobalContext.Provider>
-    </I18nDictionariesProvider>
+        <BoxedExpressionGlobalContext.Provider
+          value={{
+            supervisorHash,
+            setSupervisorHash,
+            boxedExpressionEditorRef,
+            currentlyOpenedHandlerCallback,
+            setCurrentlyOpenedHandlerCallback,
+          }}
+        >
+          <ResizerSupervisor>
+            <div className="boxed-expression-editor" ref={boxedExpressionEditorRef}>
+              <ExpressionContainer {...props.expressionDefinition} />
+            </div>
+          </ResizerSupervisor>
+        </BoxedExpressionGlobalContext.Provider>
+      </I18nDictionariesProvider>
+    ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [props.expressionDefinition]
   );
 };
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
@@ -56,6 +56,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
   entryInfoWidth = DEFAULT_ENTRY_INFO_MIN_WIDTH,
   entryExpressionWidth = DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
   isHeadless = false,
+  noHandlerMenu = false,
   onUpdatingRecursiveExpression,
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
@@ -167,7 +168,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
         rows={rows as DataRecord[]}
         onRowAdding={onRowAdding}
         onRowsUpdate={setRows}
-        handlerConfiguration={getHandlerConfiguration(i18n, i18n.contextEntry)}
+        handlerConfiguration={noHandlerMenu ? undefined : getHandlerConfiguration(i18n, i18n.contextEntry)}
         getRowKey={useCallback(getEntryKey, [])}
         resetRowCustomFunction={useCallback(resetEntry, [])}
       >

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ContextExpression/ContextExpression.tsx
@@ -16,7 +16,7 @@
 
 import "./ContextExpression.css";
 import * as React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ContextEntries,
   ContextEntryRecord,
@@ -35,11 +35,13 @@ import {
 } from "../../api";
 import { Table } from "../Table";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
-import { ColumnInstance, DataRecord } from "react-table";
+import { DataRecord } from "react-table";
 import { ContextEntryExpressionCell } from "./ContextEntryExpressionCell";
 import * as _ from "lodash";
 import { ContextEntryExpression } from "./ContextEntryExpression";
 import { ContextEntryInfoCell } from "./ContextEntryInfoCell";
+import { hashfy, Resizer } from "../Resizer";
+import { BoxedExpressionGlobalContext } from "../../context";
 
 const DEFAULT_CONTEXT_ENTRY_NAME = "ContextEntry-1";
 const DEFAULT_CONTEXT_ENTRY_DATA_TYPE = DataType.Undefined;
@@ -48,7 +50,6 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
   uid,
   name = DEFAULT_CONTEXT_ENTRY_NAME,
   dataType = DEFAULT_CONTEXT_ENTRY_DATA_TYPE,
-  onUpdatingNameAndDataType,
   contextEntries,
   result = {} as ExpressionProps,
   renderResult = true,
@@ -56,38 +57,41 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
   entryExpressionWidth = DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
   isHeadless = false,
   onUpdatingRecursiveExpression,
-  noHandlerMenu = false,
 }) => {
   const { i18n } = useBoxedExpressionEditorI18n();
 
   const [resultExpression, setResultExpression] = useState(result);
   const [infoWidth, setInfoWidth] = useState(entryInfoWidth);
   const [expressionWidth, setExpressionWidth] = useState(entryExpressionWidth);
+  const { setSupervisorHash } = React.useContext(BoxedExpressionGlobalContext);
 
-  const [columns, setColumns] = useState([
-    {
-      label: name,
-      accessor: name,
-      dataType,
-      disableHandlerOnHeader: true,
-      columns: [
-        {
-          label: "Name",
-          accessor: "entryInfo",
-          disableHandlerOnHeader: true,
-          width: infoWidth,
-          minWidth: DEFAULT_ENTRY_INFO_MIN_WIDTH,
-        },
-        {
-          label: "Value",
-          accessor: "entryExpression",
-          disableHandlerOnHeader: true,
-          width: expressionWidth,
-          minWidth: DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
-        },
-      ],
-    },
-  ]);
+  const columns = useMemo(
+    () => [
+      {
+        label: name,
+        accessor: name,
+        dataType,
+        disableHandlerOnHeader: true,
+        columns: [
+          {
+            accessor: "entryInfo",
+            disableHandlerOnHeader: true,
+            width: infoWidth,
+            setWidth: setInfoWidth,
+            minWidth: DEFAULT_ENTRY_INFO_MIN_WIDTH,
+          },
+          {
+            accessor: "entryExpression",
+            disableHandlerOnHeader: true,
+            width: expressionWidth,
+            setWidth: setExpressionWidth,
+            minWidth: DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
+          },
+        ],
+      },
+    ],
+    [dataType, expressionWidth, infoWidth, name]
+  );
 
   const [rows, setRows] = useState(
     contextEntries || [
@@ -100,23 +104,6 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
         editInfoPopoverLabel: i18n.editContextEntry,
       } as DataRecord,
     ]
-  );
-
-  const onColumnsUpdate = useCallback(
-    ([expressionColumn]: [ColumnInstance]) => {
-      onUpdatingNameAndDataType?.(expressionColumn.label as string, expressionColumn.dataType);
-      setExpressionWidth(_.find(expressionColumn.columns, { accessor: "entryExpression" })?.width as number);
-      setInfoWidth(_.find(expressionColumn.columns, { accessor: "entryInfo" })?.width as number);
-      setColumns(([prevExpressionColumn]) => [
-        {
-          ...prevExpressionColumn,
-          label: expressionColumn.label as string,
-          accessor: expressionColumn.accessor,
-          dataType: expressionColumn.dataType,
-        },
-      ]);
-    },
-    [onUpdatingNameAndDataType]
   );
 
   const onRowAdding = useCallback(
@@ -135,7 +122,7 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
   );
 
   const getHeaderVisibility = useCallback(() => {
-    return isHeadless ? TableHeaderVisibility.LastLevel : TableHeaderVisibility.Full;
+    return isHeadless ? TableHeaderVisibility.None : TableHeaderVisibility.SecondToLastLevel;
   }, [isHeadless]);
 
   useEffect(() => {
@@ -147,13 +134,27 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
       dataType: expressionColumn.dataType,
       contextEntries: rows as ContextEntries,
       result: _.omit(resultExpression, "isHeadless"),
-      ...(infoWidth > DEFAULT_ENTRY_INFO_MIN_WIDTH ? { entryInfoWidth: infoWidth } : {}),
-      ...(expressionWidth > DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH ? { entryExpressionWidth: expressionWidth } : {}),
+      entryInfoWidth: infoWidth,
+      entryExpressionWidth: expressionWidth,
     };
-    isHeadless
-      ? onUpdatingRecursiveExpression?.(_.omit(updatedDefinition, ["name", "dataType"]))
-      : window.beeApi?.broadcastContextExpressionDefinition?.(updatedDefinition);
-  }, [columns, isHeadless, onUpdatingRecursiveExpression, rows, resultExpression, infoWidth, expressionWidth, uid]);
+
+    if (isHeadless) {
+      onUpdatingRecursiveExpression?.(_.omit(updatedDefinition, ["name", "dataType"]));
+    } else {
+      setSupervisorHash(hashfy(updatedDefinition));
+      window.beeApi?.broadcastContextExpressionDefinition?.(updatedDefinition);
+    }
+  }, [
+    columns,
+    isHeadless,
+    onUpdatingRecursiveExpression,
+    rows,
+    resultExpression,
+    infoWidth,
+    expressionWidth,
+    uid,
+    setSupervisorHash,
+  ]);
 
   return (
     <div className={`context-expression ${uid}`}>
@@ -164,21 +165,33 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = ({
         defaultCell={{ entryInfo: ContextEntryInfoCell, entryExpression: ContextEntryExpressionCell }}
         columns={columns}
         rows={rows as DataRecord[]}
-        onColumnsUpdate={onColumnsUpdate}
         onRowAdding={onRowAdding}
         onRowsUpdate={setRows}
-        handlerConfiguration={noHandlerMenu ? undefined : getHandlerConfiguration(i18n, i18n.contextEntry)}
+        handlerConfiguration={getHandlerConfiguration(i18n, i18n.contextEntry)}
         getRowKey={useCallback(getEntryKey, [])}
         resetRowCustomFunction={useCallback(resetEntry, [])}
       >
         {renderResult
           ? [
-              <div key="context-result" className="context-result">{`<result>`}</div>,
-              <ContextEntryExpression
+              <Resizer
+                key="context-result"
+                width={infoWidth}
+                minWidth={DEFAULT_ENTRY_INFO_MIN_WIDTH}
+                onHorizontalResizeStop={(width) => setInfoWidth(width)}
+              >
+                <div className="context-result">{`<result>`}</div>
+              </Resizer>,
+              <Resizer
                 key="context-expression"
-                expression={resultExpression}
-                onUpdatingRecursiveExpression={setResultExpression}
-              />,
+                width={expressionWidth}
+                minWidth={DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH}
+                onHorizontalResizeStop={(width) => setExpressionWidth(width)}
+              >
+                <ContextEntryExpression
+                  expression={resultExpression}
+                  onUpdatingRecursiveExpression={setResultExpression}
+                />
+              </Resizer>,
             ]
           : undefined}
       </Table>

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.css
@@ -14,13 +14,25 @@
  * limitations under the License.
  */
 
+.expression-container .function-expression {
+  width: 100%;
+}
+
 .expression-container .function-expression .selected-function-kind {
   cursor: pointer;
   padding: 1em;
 }
 
 /** Styling .parameters-list container */
-.expression-container .function-expression > .table-component > table > thead > tr:last-of-type > th:last-of-type > .header-cell > .header-cell-info {
+.expression-container
+  .function-expression
+  > .table-component
+  > table
+  > thead
+  > tr:last-of-type
+  > th:last-of-type
+  > .header-cell
+  > .header-cell-info {
   width: 100%;
 }
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.css
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+.expression-container .invocation-expression {
+  width: 100%;
+}
+
 .expression-container .invocation-expression .function-definition-container,
 .expression-container .invocation-expression .function-definition-container .function-definition,
 /** Increasing width and height for the .header-cell-info which contains .function-definition-container */
@@ -22,15 +26,20 @@
   height: 100%;
 }
 
+.expression-container .invocation-expression .table-component table th.no-clickable-cell .header-cell-info {
+  width: 90%;
+}
+
 .expression-container .invocation-expression .function-definition-container {
   padding-right: 0.75em;
 }
 
 .expression-container .invocation-expression .function-definition-container .function-definition {
   border: none;
-  background-color: #DEF3FF;
+  background-color: #def3ff;
   font-family: monospace;
   padding: 0.25em;
+  text-align: center;
 }
 
 .expression-container .invocation-expression .function-definition-container .function-definition::placeholder {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -108,6 +108,10 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
     uid,
   ]);
 
+  const onBlurCallback = useCallback((event) => {
+    setFunctionName(event.target.value);
+  }, []);
+
   const headerCellElement = (
     <div className="function-definition-container">
       <input
@@ -115,7 +119,7 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
         type="text"
         placeholder={i18n.enterFunction}
         defaultValue={functionName}
-        onBlur={(e) => setFunctionName(e.target.value)}
+        onBlur={onBlurCallback}
       />
     </div>
   );

--- a/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/InvocationExpression/InvocationExpression.tsx
@@ -16,7 +16,7 @@
 
 import "./InvocationExpression.css";
 import * as React from "react";
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useContext, useMemo, useRef, useState } from "react";
 import {
   ContextEntries,
   ContextEntryRecord,
@@ -36,6 +36,8 @@ import { useBoxedExpressionEditorI18n } from "../../i18n";
 import { ColumnInstance, DataRecord } from "react-table";
 import { ContextEntryExpressionCell, ContextEntryInfoCell } from "../ContextExpression";
 import * as _ from "lodash";
+import { BoxedExpressionGlobalContext } from "../../context";
+import { hashfy } from "../Resizer";
 
 const DEFAULT_PARAMETER_NAME = "p-1";
 const DEFAULT_PARAMETER_DATA_TYPE = DataType.Undefined;
@@ -54,7 +56,6 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
   uid,
 }: InvocationProps) => {
   const { i18n } = useBoxedExpressionEditorI18n();
-
   const [rows, setRows] = useState(
     bindingEntries || [
       {
@@ -68,13 +69,12 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
     ]
   );
 
-  const functionDefinition = useRef<string>(invokedFunction);
+  const [infoWidth, setInfoWidth] = useState(entryInfoWidth);
+  const [expressionWidth, setExpressionWidth] = useState(entryExpressionWidth);
+  const [functionName, setFunctionName] = useState(invokedFunction);
+  const { setSupervisorHash } = useContext(BoxedExpressionGlobalContext);
 
-  const infoWidth = useRef<number>(entryInfoWidth);
-
-  const expressionWidth = useRef<number>(entryExpressionWidth);
-
-  const spreadInvocationExpressionDefinition = useCallback(() => {
+  useEffect(() => {
     const [expressionColumn] = columns.current;
 
     const updatedDefinition: InvocationProps = {
@@ -83,24 +83,30 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
       name: expressionColumn.accessor,
       dataType: expressionColumn.dataType,
       bindingEntries: rows as ContextEntries,
-      invokedFunction: functionDefinition.current,
-      ...(infoWidth.current > DEFAULT_ENTRY_INFO_MIN_WIDTH ? { entryInfoWidth: infoWidth.current } : {}),
-      ...(expressionWidth.current > DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH
-        ? { entryExpressionWidth: expressionWidth.current }
-        : {}),
+      invokedFunction: functionName,
+      entryInfoWidth: infoWidth,
+      entryExpressionWidth: expressionWidth,
     };
-    isHeadless
-      ? onUpdatingRecursiveExpression?.(_.omit(updatedDefinition, ["name", "dataType"]))
-      : window.beeApi?.broadcastInvocationExpressionDefinition?.(updatedDefinition);
-  }, [functionDefinition, isHeadless, logicType, onUpdatingRecursiveExpression, rows, uid]);
 
-  const onFunctionDefinitionChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    functionDefinition.current = e.target.value;
-  }, []);
+    const expression = _.omit(updatedDefinition, ["name", "dataType"]);
 
-  const onFunctionDefinitionBlur = useCallback(() => {
-    spreadInvocationExpressionDefinition();
-  }, [spreadInvocationExpressionDefinition]);
+    if (isHeadless) {
+      onUpdatingRecursiveExpression?.(expression);
+    } else {
+      setSupervisorHash(hashfy(expression));
+      window.beeApi?.broadcastInvocationExpressionDefinition?.(updatedDefinition);
+    }
+  }, [
+    expressionWidth,
+    functionName,
+    infoWidth,
+    isHeadless,
+    logicType,
+    onUpdatingRecursiveExpression,
+    rows,
+    setSupervisorHash,
+    uid,
+  ]);
 
   const headerCellElement = (
     <div className="function-definition-container">
@@ -108,14 +114,13 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
         className="function-definition pf-u-text-truncate"
         type="text"
         placeholder={i18n.enterFunction}
-        onChange={onFunctionDefinitionChange}
-        onBlur={onFunctionDefinitionBlur}
-        defaultValue={functionDefinition.current}
+        defaultValue={functionName}
+        onBlur={(e) => setFunctionName(e.target.value)}
       />
     </div>
   );
 
-  const columns = useRef<ColumnInstance[]>([
+  const columns = useRef([
     {
       label: name,
       accessor: name,
@@ -130,35 +135,33 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
             {
               accessor: "entryInfo",
               disableHandlerOnHeader: true,
-              canResizeOnCell: true,
-              width: infoWidth.current,
+              width: infoWidth,
+              setWidth: setInfoWidth,
               minWidth: DEFAULT_ENTRY_INFO_MIN_WIDTH,
             },
             {
               accessor: "entryExpression",
               disableHandlerOnHeader: true,
-              canResizeOnCell: true,
-              width: expressionWidth.current,
+              width: expressionWidth,
+              setWidth: setExpressionWidth,
               minWidth: DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
             },
           ],
         },
       ],
     },
-  ] as ColumnInstance[]);
+  ]);
 
   const onColumnsUpdate = useCallback(
     ([expressionColumn]: [ColumnInstance]) => {
       onUpdatingNameAndDataType?.(expressionColumn.label as string, expressionColumn.dataType);
-      infoWidth.current = _.find(expressionColumn.columns, { accessor: "entryInfo" })?.width as number;
-      expressionWidth.current = _.find(expressionColumn.columns, { accessor: "entryExpression" })?.width as number;
+
       const [updatedExpressionColumn] = columns.current;
-      updatedExpressionColumn.label = expressionColumn.label;
+      updatedExpressionColumn.label = expressionColumn.label as string;
       updatedExpressionColumn.accessor = expressionColumn.accessor;
       updatedExpressionColumn.dataType = expressionColumn.dataType;
-      spreadInvocationExpressionDefinition();
     },
-    [onUpdatingNameAndDataType, spreadInvocationExpressionDefinition]
+    [onUpdatingNameAndDataType]
   );
 
   const onRowAdding = useCallback(
@@ -180,28 +183,40 @@ export const InvocationExpression: React.FunctionComponent<InvocationProps> = ({
     return isHeadless ? TableHeaderVisibility.SecondToLastLevel : TableHeaderVisibility.Full;
   }, [isHeadless]);
 
-  useEffect(() => {
-    /** Everytime the list of items or the function definition change, we need to spread expression's updated definition */
-    spreadInvocationExpressionDefinition();
-  }, [rows, spreadInvocationExpressionDefinition]);
+  const setRowsCallback = useCallback((entries) => setRows(entries), []);
+  const getRowKeyCallback = useCallback((row) => getEntryKey(row), []);
+  const resetEntryCallback = useCallback((row) => resetEntry(row), []);
 
-  return (
-    <div className={`invocation-expression ${uid}`}>
-      <Table
-        tableId={uid}
-        headerLevels={2}
-        headerVisibility={getHeaderVisibility()}
-        skipLastHeaderGroup
-        defaultCell={{ entryInfo: ContextEntryInfoCell, entryExpression: ContextEntryExpressionCell }}
-        columns={columns.current}
-        rows={rows as DataRecord[]}
-        onColumnsUpdate={onColumnsUpdate}
-        onRowAdding={onRowAdding}
-        onRowsUpdate={setRows}
-        handlerConfiguration={getHandlerConfiguration(i18n, i18n.parameters)}
-        getRowKey={useCallback(getEntryKey, [])}
-        resetRowCustomFunction={useCallback(resetEntry, [])}
-      />
-    </div>
+  return useMemo(
+    () => (
+      <div className={`invocation-expression ${uid}`}>
+        <Table
+          tableId={uid}
+          headerLevels={2}
+          headerVisibility={getHeaderVisibility()}
+          skipLastHeaderGroup
+          defaultCell={{ entryInfo: ContextEntryInfoCell, entryExpression: ContextEntryExpressionCell }}
+          columns={columns.current}
+          rows={rows as DataRecord[]}
+          onColumnsUpdate={onColumnsUpdate}
+          onRowAdding={onRowAdding}
+          onRowsUpdate={setRowsCallback}
+          handlerConfiguration={getHandlerConfiguration(i18n, i18n.parameters)}
+          getRowKey={getRowKeyCallback}
+          resetRowCustomFunction={resetEntryCallback}
+        />
+      </div>
+    ),
+    [
+      getHeaderVisibility,
+      getRowKeyCallback,
+      i18n,
+      onColumnsUpdate,
+      onRowAdding,
+      resetEntryCallback,
+      rows,
+      setRowsCallback,
+      uid,
+    ]
   );
 };

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -18,9 +18,7 @@
 }
 
 .expression-container .literal-expression .pf-c-drawer {
-  --pf-c-drawer__splitter--after--BorderLeftWidth: var(
-    --pf-global--BorderWidth--sm
-  );
+  --pf-c-drawer__splitter--after--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
   position: absolute;
   min-width: 0.625rem;
   right: 0;
@@ -46,9 +44,9 @@
   justify-content: center;
   flex-wrap: wrap;
   position: relative;
-  padding: 0.5em 0.8em 0.5em 0.5em;
+  padding: 0.5em 0.1em 0.5em 0.5em;
   border-style: ridge;
-  background-color: #DEF3FF;
+  background-color: #def3ff;
   color: black;
 }
 
@@ -59,6 +57,7 @@
 .literal-expression .literal-expression-body {
   height: 4em;
   width: 100%;
+  border: 1px solid #eaeaea;
 }
 
 .literal-expression .literal-expression-body textarea {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -33,7 +33,6 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
   width,
 }: LiteralExpressionProps) => {
   const HEADER_WIDTH = 250;
-  const HEADER_HEIGHT = 40;
 
   const [expressionName, setExpressionName] = useState<string>(name);
   const [expressionDataType, setExpressionDataType] = useState<DataType>(dataType);
@@ -86,9 +85,7 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
     (element) => (
       <Resizer
         width={literalExpressionWidth.current}
-        height={HEADER_HEIGHT}
         minWidth={HEADER_WIDTH}
-        minHeight={HEADER_HEIGHT}
         onHorizontalResizeStop={onHorizontalResizeStop}
       >
         {element}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.css
@@ -37,6 +37,6 @@
 }
 
 .expression-container .logic-type-selector.logic-type-selected {
-  cursor: cell;
+  cursor: default;
   padding: 0.5em;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.css
@@ -23,7 +23,12 @@
   display: -webkit-flex;
   min-width: 15em;
   min-height: 4em;
-  overflow-x: auto;
+  overflow: hidden;
+  transition: background-color 0.1s ease;
+}
+
+.expression-container .logic-type-selector:hover {
+  background-color: #eff5f8;
 }
 
 .expression-container .logic-type-selector.logic-type-not-present {
@@ -32,6 +37,6 @@
 }
 
 .expression-container .logic-type-selector.logic-type-selected {
-  cursor: default;
-  padding: .5em;
+  cursor: cell;
+  padding: 0.5em;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/RelationExpression/RelationExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/RelationExpression/RelationExpression.css
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-.relation-expression {
+.expression-container .relation-expression {
   width: 100%;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/Resizer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/Resizer.css
@@ -21,4 +21,39 @@
     with the !important card
     */
   height: 100% !important;
+  position: relative;
+}
+
+.expression-container .pf-c-drawer {
+  opacity: 0.3;
+  width: 5px;
+}
+
+.expression-container .pf-c-drawer__splitter::after {
+  border: none;
+}
+
+.expression-container .pf-c-drawer .pf-c-drawer__splitter-handle::after {
+  border-left: none;
+  position: absolute;
+  left: -1px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.expression-container
+  .react-resizable
+  table
+  td:last-child
+  > .react-resizable
+  > .pf-c-drawer
+  .pf-c-drawer__splitter-handle::after,
+.expression-container
+  .react-resizable
+  table
+  th:last-child
+  > .react-resizable
+  > .pf-c-drawer
+  .pf-c-drawer__splitter-handle::after {
+  opacity: 0;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/ResizerSupervisor.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/ResizerSupervisor.tsx
@@ -14,6 +14,23 @@
  * limitations under the License.
  */
 
-.expression-container .list-expression {
-  width: 100%;
+import "./Resizer.css";
+import * as React from "react";
+import { applyDOMSupervisor } from "./dom";
+import { useEffect, useContext } from "react";
+import { BoxedExpressionGlobalContext } from "../../context";
+
+export interface ResizerSupervisorProps {
+  children?: React.ReactElement;
 }
+
+export const ResizerSupervisor: React.FunctionComponent<ResizerSupervisorProps> = ({ children }) => {
+  const { supervisorHash } = useContext(BoxedExpressionGlobalContext);
+
+  useEffect(() => {
+    const id = setTimeout(applyDOMSupervisor, 0);
+    return () => clearTimeout(id);
+  }, [supervisorHash]);
+
+  return <div>{children}</div>;
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/common/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/common/index.ts
@@ -14,6 +14,29 @@
  * limitations under the License.
  */
 
-export * from "./Resizer";
-export * from "./ResizerSupervisor";
-export * from "./common";
+export const DEFAULT_MIN_WIDTH = 150;
+
+/*
+ * Returns a valid width value.
+ */
+export const widthValue = (width: number | string | undefined | null): number => {
+  return Math.max(Math.round(parseFloat(width + "")), DEFAULT_MIN_WIDTH);
+};
+
+/*
+ * Generates a global supervisor hash for a given object.
+ */
+export const hashfy = (obj = {}): string => {
+  return JSON.stringify(obj);
+};
+
+/*
+ * Propagate Cell width from DOM to React state.
+ */
+export const notifyCell = (id: string, width: number = DEFAULT_MIN_WIDTH): void => {
+  document.dispatchEvent(
+    new CustomEvent(id, {
+      detail: { width },
+    })
+  );
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/Cell.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/Cell.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as _ from "lodash";
+import { notifyCell, widthValue } from "../common";
+
+const RESIZER_PADDING = 14;
+const BORDER = 1;
+
+export class Cell {
+  private id?: string;
+  private lastColumn?: boolean;
+  private rect?: DOMRect;
+  private parentRow?: HTMLTableRowElement | null;
+
+  constructor(public element: HTMLElement, public children: Cell[], public depth: number) {}
+
+  getId(): string {
+    if (!this.id) {
+      this.id = _.first([].slice.call(this.element.classList).filter((c: string) => c.match(/uuid-/g))) || "";
+    }
+    return this.id;
+  }
+
+  getRect(): DOMRect {
+    if (!this.rect) {
+      this.rect = this.element.getBoundingClientRect();
+    }
+    return this.rect;
+  }
+
+  isLastColumn(): boolean {
+    if (!this.lastColumn) {
+      this.lastColumn = this.getParentRow()?.lastChild === this.element.closest("th, td");
+    }
+    return this.lastColumn;
+  }
+
+  setWidth(width: number): void {
+    const cellWidth = widthValue(width);
+    notifyCell(this.getId(), cellWidth);
+    this.element.style.width = cellWidth + "px";
+  }
+
+  refreshWidthAsParent(): void {
+    if (this.children.length > 0) {
+      this.setWidth(this.fetchChildWidth() + RESIZER_PADDING);
+    }
+  }
+
+  refreshWidthAsLastColumn(): void {
+    if (!this.isLastColumn()) {
+      return;
+    }
+
+    const parentRect = this.getParentRow()?.getBoundingClientRect();
+
+    if (parentRect) {
+      this.setWidth(Math.round(parentRect.right) - Math.round(this.getRect().x) - BORDER);
+    }
+  }
+
+  private getParentRow() {
+    if (!this.parentRow) {
+      this.parentRow = this.element.closest("tr");
+    }
+    return this.parentRow;
+  }
+
+  private fetchChildWidth() {
+    const thead = this.element.querySelector("thead, tbody");
+    return widthValue(thead?.getBoundingClientRect().width);
+  }
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/DOMSession.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/DOMSession.ts
@@ -16,7 +16,7 @@
 
 import { Cell } from "./";
 
-export const CELL_CSS_SELCTOR = ".react-resizable";
+export const CELL_CSS_SELECTOR = ".react-resizable";
 
 export class DOMSession {
   private cells: Cell[] | undefined;
@@ -56,7 +56,7 @@ export class DOMSession {
   }
 
   private fetchCellElements(parent: HTMLElement): HTMLElement[] {
-    const htmlElements = parent.querySelectorAll(CELL_CSS_SELCTOR);
+    const htmlElements = parent.querySelectorAll(CELL_CSS_SELECTOR);
     return [].slice.call(htmlElements);
   }
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/DOMSession.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/DOMSession.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Cell } from "./";
+
+export const CELL_CSS_SELCTOR = ".react-resizable";
+
+export class DOMSession {
+  private cells: Cell[] | undefined;
+
+  getCells(): Cell[] {
+    if (this.cells === undefined) {
+      this.cells = this.buildCells();
+    }
+    return this.cells;
+  }
+
+  private buildCells() {
+    const cells: Cell[] = [];
+    this.fetchCellElements(document.body).forEach((cellElement) => {
+      this.buildCell(cellElement, cells, 0);
+    });
+    return cells;
+  }
+
+  private buildCell(htmlElement: HTMLElement, cells: Cell[], depthLevel: number): Cell {
+    const exitingElement = cells.find((c) => c.element === htmlElement);
+    if (exitingElement) {
+      return exitingElement;
+    }
+
+    const cell = new Cell(
+      htmlElement,
+      this.fetchCellElements(htmlElement)
+        .map((child) => this.buildCell(child, cells, depthLevel + 1))
+        .filter((c) => c.depth == depthLevel + 1),
+      depthLevel
+    );
+
+    cells.push(cell);
+
+    return cell;
+  }
+
+  private fetchCellElements(parent: HTMLElement): HTMLElement[] {
+    const htmlElements = parent.querySelectorAll(CELL_CSS_SELCTOR);
+    return [].slice.call(htmlElements);
+  }
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/ResizerSupervisorDOM.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/ResizerSupervisorDOM.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DOMSession, Cell } from "../dom";
+
+/*
+ * =============================================================================
+ * React state + hooks abstractions have a level of granularity that limits the
+ * frame hate in the context of resizable boxed expression cells.
+ *
+ * This component intentionally accesses DOM elements, but it also propagates
+ * new width information across React components once users commit an action.
+ * =============================================================================
+ */
+export const applyDOMSupervisor = (): void => {
+  new SupervisorExecution().execute();
+};
+
+class SupervisorExecution {
+  domSession: DOMSession;
+
+  constructor() {
+    this.domSession = new DOMSession();
+  }
+
+  execute() {
+    const cells = this.domSession.getCells();
+    cells.sort((c1, c2) => c2.depth - c1.depth).forEach(this.refreshWidthAsParent);
+    cells.sort((c1, c2) => c1.depth - c2.depth).forEach(this.refreshWidthAsLastColumn);
+  }
+
+  private refreshWidthAsParent(cell: Cell) {
+    cell.refreshWidthAsParent();
+  }
+
+  private refreshWidthAsLastColumn(cell: Cell) {
+    cell.refreshWidthAsLastColumn();
+  }
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/dom/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export * from "./Resizer";
-export * from "./ResizerSupervisor";
-export * from "./common";
+export * from "./Cell";
+export * from "./DOMSession";
+export * from "./ResizerSupervisorDOM";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
-.expression-container .table-component {
-  overflow-x: auto;
-}
-
+.expression-container .table-component,
 .expression-container .table-component table {
   font-style: normal;
+  width: 100%;
+}
+
+.expression-container .table-component,
+.expression-container .table-component table,
+.expression-container .table-component table thead,
+.expression-container .table-component table thead tr,
+.expression-container .table-component table tbody,
+.expression-container .table-component table tbody tr {
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .expression-container .table-component table thead,
@@ -33,7 +41,7 @@
 .expression-container .table-component table th {
   min-height: 55px;
   position: relative;
-  padding: 0.7em;
+  padding: 0.7em 0;
   border-style: ridge;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
@@ -57,7 +65,7 @@
 
 .expression-container .table-component table th:not(:first-child) {
   text-align: center;
-  background-color: #DEF3FF;
+  background-color: #def3ff;
 }
 
 .expression-container .table-component table th.no-clickable-cell:first-of-type .header-cell,
@@ -76,19 +84,14 @@
   height: 4em;
 }
 
-.expression-container .table-component table tbody:not(.missing-header),
-.expression-container .table-component table thead tr + tr {
-  margin-top: -2px;
-}
-
 .expression-container .table-component table thead th,
 .expression-container .table-component table tbody td {
-  border: 1px solid #CCC;
+  border: 1px solid #ccc;
 }
 
 /** Table Body rules */
 
-.expression-container .table-component table tbody tr {
+.expression-container .table-component table tr {
   display: flex;
   border: 0;
 }
@@ -97,7 +100,7 @@
   border-style: ridge;
   padding: 1.1em 0;
   text-align: center;
-  overflow: auto;
+  overflow: hidden;
 }
 
 .expression-container .table-component table tbody td + td {
@@ -118,26 +121,18 @@
   min-width: 60px;
 }
 
-.expression-container .table-component table tbody tr.table-row,
-.expression-container .table-component table tbody td.data-cell {
-  width: 100%;
-  overflow-y: hidden;
-}
-
 .expression-container .table-component table tbody td.data-cell.has-resizer .logic-type-selector.logic-type-selected {
-  padding: .5em 1.2em .5em .5em;
+  padding: 0.5em 1.2em 0.5em 0.5em;
 }
 
 /** Drawer for resizing columns */
 
-.expression-container .table-component table .pf-c-drawer__splitter {
+.expression-container .pf-c-drawer__splitter {
   background-color: inherit;
 }
 
-.expression-container .table-component table .pf-c-drawer {
-  --pf-c-drawer__splitter--after--BorderLeftWidth: var(
-    --pf-global--BorderWidth--sm
-  );
+.expression-container .pf-c-drawer {
+  --pf-c-drawer__splitter--after--BorderLeftWidth: var(--pf-global--BorderWidth--sm);
   position: absolute;
   min-width: 0.625rem;
   right: 0;
@@ -145,21 +140,21 @@
   bottom: 0;
 }
 
-.expression-container .table-component table .pf-c-drawer.resizer-disabled * {
+.expression-container .pf-c-drawer.resizer-disabled * {
   cursor: not-allowed;
 }
 
-.expression-container .table-component table .pf-c-drawer.resizer-disabled .pf-c-drawer__splitter {
+.expression-container .pf-c-drawer.resizer-disabled .pf-c-drawer__splitter {
   background-color: lightgray;
 }
 
-.expression-container .table-component table .pf-c-drawer.drawer-on-body > .pf-c-drawer__splitter > .pf-c-drawer__splitter-handle {
+.expression-container
+  .table-component
+  table
+  .pf-c-drawer.drawer-on-body
+  > .pf-c-drawer__splitter
+  > .pf-c-drawer__splitter-handle {
   z-index: 1;
-}
-
-.expression-container .table-component table .pf-c-drawer.drawer-on-body > .pf-c-drawer__splitter::after {
-  border-width: 1px;
-  background-color: white;
 }
 
 /** Text-area used as a cell */

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.tsx
@@ -26,7 +26,7 @@ import {
 } from "react-table";
 import { TableComposable } from "@patternfly/react-table";
 import * as React from "react";
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useRef, useState, useEffect } from "react";
 import { EditableCell } from "./EditableCell";
 import { TableHeaderVisibility, TableOperation, TableProps } from "../../api";
 import * as _ from "lodash";
@@ -165,8 +165,6 @@ export const Table: React.FunctionComponent<TableProps> = ({
   );
 
   const defaultColumn = {
-    minWidth: 150,
-    width: 150,
     Cell: useCallback((cellRef) => {
       const column = cellRef.column as ColumnInstance;
       if (column.isCountColumn) {
@@ -243,31 +241,6 @@ export const Table: React.FunctionComponent<TableProps> = ({
     useResizeColumns
   );
 
-  const resizeNestedColumns = (columns: ColumnInstance[], accessor: string, updatedWidth: number) => {
-    const columnIndex = _.findIndex(columns, { accessor });
-    if (columnIndex >= 0) {
-      const updatedColumn = { ...columns[columnIndex] };
-      updatedColumn.width = updatedWidth;
-      columns.splice(columnIndex, 1, updatedColumn);
-    } else {
-      _.forEach(columns, (column) => resizeNestedColumns(column.columns, accessor, updatedWidth));
-    }
-  };
-
-  const finishedResizing =
-    tableInstance.state.columnResizing.isResizingColumn === null &&
-    !_.isEmpty(tableInstance.state.columnResizing.columnWidths);
-  useEffect(() => {
-    if (finishedResizing) {
-      _.forEach(tableInstance.state.columnResizing.columnWidths, (updatedColumnWidth, accessor) =>
-        resizeNestedColumns(tableColumns.current as ColumnInstance[], accessor, updatedColumnWidth)
-      );
-      onColumnsUpdateCallback(tableColumns.current);
-    }
-    // Need to consider a change only when resizing is finished (no other dependencies to consider for this useEffect)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [finishedResizing]);
-
   return (
     <div className={`table-component ${tableId}`}>
       <TableComposable variant="compact" {...tableInstance.getTableProps()} ref={tableRef}>
@@ -286,6 +259,7 @@ export const Table: React.FunctionComponent<TableProps> = ({
           tableInstance={tableInstance}
           getRowKey={getRowKey}
           getColumnKey={getColumnKey}
+          onColumnsUpdate={onColumnsUpdateCallback}
           headerVisibility={headerVisibility}
         >
           {children}

--- a/kie-wb-common-react/boxed-expression-editor/src/context/BoxedExpressionGlobalContext.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/context/BoxedExpressionGlobalContext.tsx
@@ -17,6 +17,8 @@
 import * as React from "react";
 
 export interface BoxedExpressionGlobalContextProps {
+  supervisorHash: string;
+  setSupervisorHash: (hash: string) => void;
   boxedExpressionEditorRef: React.RefObject<HTMLDivElement>;
   currentlyOpenedHandlerCallback: React.Dispatch<React.SetStateAction<boolean>>;
   setCurrentlyOpenedHandlerCallback: React.Dispatch<

--- a/kie-wb-common-react/boxed-expression-editor/yarn.lock
+++ b/kie-wb-common-react/boxed-expression-editor/yarn.lock
@@ -865,6 +865,11 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/webpack-sources@*":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz#8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10"
@@ -8697,7 +8702,7 @@ uuid@^3.1.0, uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
[KOGITO-4520](https://issues.redhat.com/browse/KOGITO-4520): Design and adopt a strategy for auto/manual resize the Table columns in the Boxed Expression Editor

Here's the live demo: [karreiro.com/kogito-editors-java](https://karreiro.com/kogito-editors-java/)

![2021-05-17 13 57 12](https://user-images.githubusercontent.com/1079279/118484954-1a1ae380-b718-11eb-8144-07a516d30505.gif)

This PR doesn't aim to cover [KOGITO-4587](https://issues.redhat.com/browse/KOGITO-4587) and [KOGITO-5131](https://issues.redhat.com/browse/KOGITO-5131).