### PR TITLE
KOGITO-3651 Create "PMMLFunction" component + KOGITO-3652 Create "PMMLLiteralExpression" component

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/.gitignore
+++ b/kie-wb-common-react/boxed-expression-editor/.gitignore
@@ -7,3 +7,4 @@ stats.json
 .idea
 /coverage/
 react-app-env.d.ts
+/showcase/.eslintcache

--- a/kie-wb-common-react/boxed-expression-editor/.gitignore
+++ b/kie-wb-common-react/boxed-expression-editor/.gitignore
@@ -7,4 +7,3 @@ stats.json
 .idea
 /coverage/
 react-app-env.d.ts
-/showcase/.eslintcache

--- a/kie-wb-common-react/boxed-expression-editor/showcase/.gitignore
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/.gitignore
@@ -1,0 +1,1 @@
+.eslintcache

--- a/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/src/index.tsx
@@ -39,6 +39,34 @@ export const App: React.FunctionComponent = () => {
     dataType: DataType.Undefined,
   };
 
+  const pmmlParams = [
+    {
+      document: "mining pmml",
+      modelsFromDocument: [
+        {
+          model: "MiningModelSum",
+          parametersFromModel: [
+            { name: "input1", dataType: DataType.Any },
+            { name: "input2", dataType: DataType.Any },
+            { name: "input3", dataType: DataType.Any },
+          ],
+        },
+      ],
+    },
+    {
+      document: "regression pmml",
+      modelsFromDocument: [
+        {
+          model: "RegressionLinear",
+          parametersFromModel: [
+            { name: "i1", dataType: DataType.Number },
+            { name: "i2", dataType: DataType.Number },
+          ],
+        },
+      ],
+    },
+  ];
+
   const [updatedExpression, setUpdatedExpression] = useState(selectedExpression);
 
   const expressionDefinition: ExpressionContainerProps = { selectedExpression };
@@ -57,7 +85,7 @@ export const App: React.FunctionComponent = () => {
   return (
     <div className="showcase">
       <div className="boxed-expression">
-        <BoxedExpressionEditor expressionDefinition={expressionDefinition} />
+        <BoxedExpressionEditor expressionDefinition={expressionDefinition} pmmlParams={pmmlParams} />
       </div>
       <div className="updated-json">
         <p className="disclaimer">

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
@@ -30,6 +30,11 @@ import * as _ from "lodash";
 import { BoxedExpressionGlobalContext } from "../../../context";
 
 describe("FunctionExpression tests", () => {
+  const documentName = "document";
+  const model = "model";
+  const parametersFromModel: EntryInfo[] = [{ name: "p-1", dataType: DataType.Number }];
+  const modelsFromDocument = [{ model, parametersFromModel }];
+
   test("should show a table with two levels visible header, with one row and one column", () => {
     const { container } = render(
       usingTestingBoxedExpressionI18nContext(
@@ -245,22 +250,6 @@ describe("FunctionExpression tests", () => {
       checkFormalParameters(mockedBroadcastDefinition, []);
     });
 
-    function wrapComponentInContext(component: JSX.Element) {
-      return (
-        <BoxedExpressionGlobalContext.Provider
-          value={{
-            supervisorHash: "",
-            setSupervisorHash: jest.fn,
-            boxedExpressionEditorRef: { current: document.body as HTMLDivElement },
-            currentlyOpenedHandlerCallback: jest.fn,
-            setCurrentlyOpenedHandlerCallback: jest.fn,
-          }}
-        >
-          {component}
-        </BoxedExpressionGlobalContext.Provider>
-      );
-    }
-
     function checkFormalParameters(mockedBroadcastDefinition: jest.Mock, formalParameters: EntryInfo[]) {
       expect(mockedBroadcastDefinition).toHaveBeenCalledWith({
         dataType: DataType.Undefined,
@@ -383,23 +372,16 @@ describe("FunctionExpression tests", () => {
     test("should populate parameters list with parameters related to selected PMML model", async () => {
       const mockedBroadcastDefinition = jest.fn();
       mockBroadcastDefinition(mockedBroadcastDefinition);
-      const document = "document";
-      const model = "model";
-      const parametersFromModel: EntryInfo[] = [{ name: "p-1", dataType: DataType.Number }];
-      const modelsFromDocument = [{ model, parametersFromModel }];
 
       const { baseElement, container } = render(
         usingTestingBoxedExpressionI18nContext(
-          <FunctionExpression
-            logicType={LogicType.Function}
-            functionKind={FunctionKind.Pmml}
-            formalParameters={[]}
-            pmmlParams={[{ document, modelsFromDocument }]}
-          />
+          wrapComponentInContext(
+            <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Pmml} formalParameters={[]} />
+          )
         ).wrapper
       );
       await openPMMLLiteralExpressionSelector(container, 0);
-      await selectPMMLElement(baseElement, document);
+      await selectPMMLElement(baseElement, documentName);
       await openPMMLLiteralExpressionSelector(container, 1);
       await selectPMMLElement(baseElement, model);
 
@@ -410,6 +392,23 @@ describe("FunctionExpression tests", () => {
       );
     });
   });
+
+  function wrapComponentInContext(component: JSX.Element) {
+    return (
+      <BoxedExpressionGlobalContext.Provider
+        value={{
+          pmmlParams: [{ document: documentName, modelsFromDocument }],
+          supervisorHash: "",
+          setSupervisorHash: jest.fn,
+          boxedExpressionEditorRef: { current: document.body as HTMLDivElement },
+          currentlyOpenedHandlerCallback: jest.fn,
+          setCurrentlyOpenedHandlerCallback: jest.fn,
+        }}
+      >
+        {component}
+      </BoxedExpressionGlobalContext.Provider>
+    );
+  }
 
   function mockBroadcastDefinition(mockedBroadcastDefinition: jest.Mock) {
     window.beeApi = _.extend(window.beeApi || {}, {

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/FunctionExpression/FunctionExpression.test.tsx
@@ -27,6 +27,7 @@ import * as React from "react";
 import { DataType, EntryInfo, FunctionKind, FunctionProps, LogicType } from "../../../api";
 import { act } from "react-dom/test-utils";
 import * as _ from "lodash";
+import { BoxedExpressionGlobalContext } from "../../../context";
 
 describe("FunctionExpression tests", () => {
   test("should show a table with two levels visible header, with one row and one column", () => {
@@ -73,7 +74,7 @@ describe("FunctionExpression tests", () => {
     await clearTableRow(container, baseElement);
 
     expect(mockedBroadcastDefinition).toHaveBeenLastCalledWith({
-      dataType: undefined,
+      dataType: DataType.Undefined,
       expression: {
         uid: "id1",
       },
@@ -94,7 +95,9 @@ describe("FunctionExpression tests", () => {
     test("should render no parameter, if passed property is empty array", async () => {
       const { container, baseElement } = render(
         usingTestingBoxedExpressionI18nContext(
-          <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Feel} formalParameters={[]} />
+          wrapComponentInContext(
+            <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Feel} formalParameters={[]} />
+          )
         ).wrapper
       );
       await activateSelector(container as HTMLElement, ".parameters-list");
@@ -110,11 +113,13 @@ describe("FunctionExpression tests", () => {
 
       const { container, baseElement } = render(
         usingTestingBoxedExpressionI18nContext(
-          <FunctionExpression
-            logicType={LogicType.Function}
-            functionKind={FunctionKind.Feel}
-            formalParameters={[{ name: paramName, dataType: paramDataType }]}
-          />
+          wrapComponentInContext(
+            <FunctionExpression
+              logicType={LogicType.Function}
+              functionKind={FunctionKind.Feel}
+              formalParameters={[{ name: paramName, dataType: paramDataType }]}
+            />
+          )
         ).wrapper
       );
       await activateSelector(container as HTMLElement, ".parameters-list");
@@ -131,11 +136,13 @@ describe("FunctionExpression tests", () => {
 
       const { container, baseElement } = render(
         usingTestingBoxedExpressionI18nContext(
-          <FunctionExpression
-            logicType={LogicType.Function}
-            functionKind={FunctionKind.Feel}
-            formalParameters={[{ name: "param", dataType: DataType.Any }]}
-          />
+          wrapComponentInContext(
+            <FunctionExpression
+              logicType={LogicType.Function}
+              functionKind={FunctionKind.Feel}
+              formalParameters={[{ name: "param", dataType: DataType.Any }]}
+            />
+          )
         ).wrapper
       );
       await activateSelector(container as HTMLElement, ".parameters-list");
@@ -159,11 +166,13 @@ describe("FunctionExpression tests", () => {
 
       const { container, baseElement } = render(
         usingTestingBoxedExpressionI18nContext(
-          <FunctionExpression
-            logicType={LogicType.Function}
-            functionKind={FunctionKind.Feel}
-            formalParameters={[{ name: "param", dataType: DataType.Undefined }]}
-          />
+          wrapComponentInContext(
+            <FunctionExpression
+              logicType={LogicType.Function}
+              functionKind={FunctionKind.Feel}
+              formalParameters={[{ name: "param", dataType: DataType.Undefined }]}
+            />
+          )
         ).wrapper
       );
       await activateSelector(container as HTMLElement, ".parameters-list");
@@ -190,7 +199,9 @@ describe("FunctionExpression tests", () => {
 
       const { container, baseElement } = render(
         usingTestingBoxedExpressionI18nContext(
-          <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Feel} formalParameters={[]} />
+          wrapComponentInContext(
+            <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Feel} formalParameters={[]} />
+          )
         ).wrapper
       );
       await activateSelector(container as HTMLElement, ".parameters-list");
@@ -212,16 +223,18 @@ describe("FunctionExpression tests", () => {
 
       const { container, baseElement } = render(
         usingTestingBoxedExpressionI18nContext(
-          <FunctionExpression
-            logicType={LogicType.Function}
-            functionKind={FunctionKind.Feel}
-            formalParameters={[
-              {
-                dataType: DataType.Undefined,
-                name: DEFAULT_FIRST_PARAM_NAME,
-              },
-            ]}
-          />
+          wrapComponentInContext(
+            <FunctionExpression
+              logicType={LogicType.Function}
+              functionKind={FunctionKind.Feel}
+              formalParameters={[
+                {
+                  dataType: DataType.Undefined,
+                  name: DEFAULT_FIRST_PARAM_NAME,
+                },
+              ]}
+            />
+          )
         ).wrapper
       );
       await activateSelector(container as HTMLElement, ".parameters-list");
@@ -232,9 +245,25 @@ describe("FunctionExpression tests", () => {
       checkFormalParameters(mockedBroadcastDefinition, []);
     });
 
+    function wrapComponentInContext(component: JSX.Element) {
+      return (
+        <BoxedExpressionGlobalContext.Provider
+          value={{
+            supervisorHash: "",
+            setSupervisorHash: jest.fn,
+            boxedExpressionEditorRef: { current: document.body as HTMLDivElement },
+            currentlyOpenedHandlerCallback: jest.fn,
+            setCurrentlyOpenedHandlerCallback: jest.fn,
+          }}
+        >
+          {component}
+        </BoxedExpressionGlobalContext.Provider>
+      );
+    }
+
     function checkFormalParameters(mockedBroadcastDefinition: jest.Mock, formalParameters: EntryInfo[]) {
       expect(mockedBroadcastDefinition).toHaveBeenCalledWith({
-        dataType: undefined,
+        dataType: DataType.Undefined,
         expression: {
           logicType: "Literal expression",
         },
@@ -298,23 +327,7 @@ describe("FunctionExpression tests", () => {
         ).wrapper
       );
 
-      expect(container.querySelector(".function-expression table tbody td.data-cell")).toBeVisible();
-      expect(container.querySelector(".function-expression table tbody td.data-cell .context-expression")).toBeTruthy();
-      expect(
-        container.querySelectorAll(
-          ".function-expression table tbody td.data-cell .context-expression .context-entry-info-cell"
-        )
-      ).toHaveLength(2);
-      expect(
-        container.querySelectorAll(
-          ".function-expression table tbody td.data-cell .context-expression .context-entry-info-cell"
-        )[0]
-      ).toContainHTML("class");
-      expect(
-        container.querySelectorAll(
-          ".function-expression table tbody td.data-cell .context-expression .context-entry-info-cell"
-        )[1]
-      ).toContainHTML("method");
+      checkContextEntries(container, "class", "method");
     });
 
     test("should show an entry corresponding to the passed class and method values", () => {
@@ -333,21 +346,68 @@ describe("FunctionExpression tests", () => {
         ).wrapper
       );
 
-      expect(
-        container.querySelectorAll(
-          ".function-expression table tbody td.data-cell .context-expression .context-entry-expression-cell"
-        )
-      ).toHaveLength(2);
-      expect(
-        container.querySelectorAll(
-          ".function-expression table tbody td.data-cell .context-expression .context-entry-expression-cell"
-        )[0]
-      ).toContainHTML(classValue);
-      expect(
-        container.querySelectorAll(
-          ".function-expression table tbody td.data-cell .context-expression .context-entry-expression-cell"
-        )[1]
-      ).toContainHTML(methodValue);
+      checkContextEntries(container, classValue, methodValue, true);
+    });
+  });
+
+  describe("PMML Function Kind", () => {
+    test("should show, by default, an entry with a context table, containing two entries: document and model", () => {
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression logicType={LogicType.Function} functionKind={FunctionKind.Pmml} formalParameters={[]} />
+        ).wrapper
+      );
+
+      checkContextEntries(container, "document", "model");
+    });
+
+    test("should show an entry corresponding to the passed document and model values", () => {
+      const document = "document";
+      const model = "model";
+
+      const { container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression
+            logicType={LogicType.Function}
+            functionKind={FunctionKind.Pmml}
+            formalParameters={[]}
+            document={document}
+            model={model}
+          />
+        ).wrapper
+      );
+
+      checkContextEntries(container, document, model, true);
+    });
+
+    test("should populate parameters list with parameters related to selected PMML model", async () => {
+      const mockedBroadcastDefinition = jest.fn();
+      mockBroadcastDefinition(mockedBroadcastDefinition);
+      const document = "document";
+      const model = "model";
+      const parametersFromModel: EntryInfo[] = [{ name: "p-1", dataType: DataType.Number }];
+      const modelsFromDocument = [{ model, parametersFromModel }];
+
+      const { baseElement, container } = render(
+        usingTestingBoxedExpressionI18nContext(
+          <FunctionExpression
+            logicType={LogicType.Function}
+            functionKind={FunctionKind.Pmml}
+            formalParameters={[]}
+            pmmlParams={[{ document, modelsFromDocument }]}
+          />
+        ).wrapper
+      );
+      await openPMMLLiteralExpressionSelector(container, 0);
+      await selectPMMLElement(baseElement, document);
+      await openPMMLLiteralExpressionSelector(container, 1);
+      await selectPMMLElement(baseElement, model);
+
+      expect(mockedBroadcastDefinition).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          formalParameters: parametersFromModel,
+        })
+      );
     });
   });
 
@@ -374,6 +434,33 @@ describe("FunctionExpression tests", () => {
       );
       await flushPromises();
       await jest.runAllTimers();
+    });
+  }
+
+  function checkContextEntries(container: Element, firstEntry: string, secondEntry: string, checkExpression = false) {
+    const specificClassToCheck = checkExpression ? ".context-entry-expression-cell" : ".context-entry-info-cell";
+    const entriesSelector = `.function-expression table tbody td.data-cell .context-expression ${specificClassToCheck}`;
+
+    expect(container.querySelector(".function-expression table tbody td.data-cell")).toBeVisible();
+    expect(container.querySelector(".function-expression table tbody td.data-cell .context-expression")).toBeTruthy();
+    expect(container.querySelectorAll(entriesSelector)).toHaveLength(2);
+    expect(container.querySelectorAll(entriesSelector)[0]).toContainHTML(firstEntry);
+    expect(container.querySelectorAll(entriesSelector)[1]).toContainHTML(secondEntry);
+  }
+
+  async function openPMMLLiteralExpressionSelector(container: Element, position: number) {
+    await act(async () => {
+      (container.querySelectorAll(".pmml-literal-expression button")[position]! as HTMLElement).click();
+      await flushPromises();
+      jest.runAllTimers();
+    });
+  }
+
+  async function selectPMMLElement(baseElement: Element, element: string) {
+    await act(async () => {
+      (baseElement.querySelector(`[data-ouia-component-id='${element}']`) as HTMLButtonElement).click();
+      await flushPromises();
+      jest.runAllTimers();
     });
   }
 });

--- a/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PMMLLiteralExpression/PMMLLiteralExpression.test.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/__tests__/components/PMMLLiteralExpression/PMMLLiteralExpression.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import { activateSelector, usingTestingBoxedExpressionI18nContext } from "../test-utils";
+import { LogicType } from "../../../api";
+import * as React from "react";
+import { PMMLLiteralExpression } from "../../../components/LiteralExpression";
+
+jest.useFakeTimers();
+
+describe("PMMLLiteralExpression tests", () => {
+  test("should show noOptionsLabel when no options are available", async () => {
+    const noOptionsLabel = "no options label";
+
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <PMMLLiteralExpression
+          logicType={LogicType.PMMLLiteralExpression}
+          getOptions={() => []}
+          noOptionsLabel={noOptionsLabel}
+        />
+      ).wrapper
+    );
+
+    expect(container.querySelector(".pmml-literal-expression")).toBeTruthy();
+    expect(container.querySelector(".pmml-literal-expression button")).toContainHTML(noOptionsLabel);
+  });
+
+  test("should show noOptionsLabel when selected option is not present in the options list", async () => {
+    const noOptionsLabel = "no options label";
+
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <PMMLLiteralExpression
+          logicType={LogicType.PMMLLiteralExpression}
+          getOptions={() => ["a", "b", "c"]}
+          selected="selected"
+          noOptionsLabel={noOptionsLabel}
+        />
+      ).wrapper
+    );
+
+    expect(container.querySelector(".pmml-literal-expression")).toBeTruthy();
+    expect(container.querySelector(".pmml-literal-expression button")).toContainHTML(noOptionsLabel);
+  });
+
+  test("should show selected option when it is passed and it is present in the options list", async () => {
+    const selectedOption = "selected";
+
+    const { container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <PMMLLiteralExpression
+          logicType={LogicType.PMMLLiteralExpression}
+          getOptions={() => ["a", "b", "c", selectedOption]}
+          selected={selectedOption}
+          noOptionsLabel={"no options"}
+        />
+      ).wrapper
+    );
+
+    expect(container.querySelector(".pmml-literal-expression")).toBeTruthy();
+    expect(container.querySelector(".pmml-literal-expression button")).toContainHTML(selectedOption);
+  });
+
+  test("should change the selected option when the user manually select it", async () => {
+    const changedOption = "changed";
+    const selectedOption = "selected";
+
+    const { baseElement, container } = render(
+      usingTestingBoxedExpressionI18nContext(
+        <PMMLLiteralExpression
+          logicType={LogicType.PMMLLiteralExpression}
+          getOptions={() => [changedOption, "a", "b", "c", selectedOption]}
+          selected={selectedOption}
+          noOptionsLabel={"no options"}
+        />
+      ).wrapper
+    );
+
+    await activateSelector(container as HTMLElement, ".pmml-literal-expression button");
+    (baseElement.querySelector(`[data-ouia-component-id='${changedOption}']`) as HTMLButtonElement).click();
+
+    expect(container.querySelector(".pmml-literal-expression")).toBeTruthy();
+    expect(container.querySelector(".pmml-literal-expression button")).toContainHTML(changedOption);
+  });
+});

--- a/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/ExpressionProps.ts
@@ -51,6 +51,17 @@ export interface LiteralExpressionProps extends ExpressionProps {
   width?: number;
 }
 
+export interface PMMLLiteralExpressionProps extends ExpressionProps {
+  /** Logic type must be PMMLLiteralExpression */
+  logicType: LogicType.PMMLLiteralExpression;
+  /** Callback for retrieving the options to provide in the dropdown */
+  getOptions: () => string[];
+  /** Dropdown's selected option */
+  selected?: string;
+  /** Label displayed (in italic style) when no options are available */
+  noOptionsLabel: string;
+}
+
 export interface RelationProps extends ExpressionProps {
   /** Logic type must be Relation */
   logicType: LogicType.Relation;

--- a/kie-wb-common-react/boxed-expression-editor/src/api/FunctionKind.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/FunctionKind.ts
@@ -39,6 +39,16 @@ export interface JavaFunctionProps {
   method?: string;
 }
 
+interface PMMLParam {
+  document: string;
+  modelsFromDocument?: {
+    model: string;
+    parametersFromModel?: EntryInfo[];
+  }[];
+}
+
+export type PMMLParams = PMMLParam[];
+
 export interface PmmlFunctionProps {
   /** Pmml Function */
   functionKind: FunctionKind.Pmml;
@@ -46,12 +56,4 @@ export interface PmmlFunctionProps {
   document?: string;
   /** Selected PMML model */
   model?: string;
-  /** Input PMML parameters */
-  pmmlParams?: {
-    document: string;
-    modelsFromDocument?: {
-      model: string;
-      parametersFromModel?: EntryInfo[];
-    }[];
-  }[];
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/api/FunctionKind.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/api/FunctionKind.ts
@@ -15,6 +15,7 @@
  */
 
 import { ExpressionProps } from "./ExpressionProps";
+import { EntryInfo } from "./ContextEntry";
 
 export enum FunctionKind {
   Feel = "FEEL",
@@ -41,8 +42,16 @@ export interface JavaFunctionProps {
 export interface PmmlFunctionProps {
   /** Pmml Function */
   functionKind: FunctionKind.Pmml;
-  /** PMML document */
+  /** Selected PMML document */
   document?: string;
-  /** PMML model */
+  /** Selected PMML model */
   model?: string;
+  /** Input PMML parameters */
+  pmmlParams?: {
+    document: string;
+    modelsFromDocument?: {
+      model: string;
+      parametersFromModel?: EntryInfo[];
+    }[];
+  }[];
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.tsx
@@ -15,13 +15,13 @@
  */
 
 import * as React from "react";
-import { useRef, useState, useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
 import "@patternfly/react-core/dist/styles/base-no-reset.css";
 import "@patternfly/react-styles/css/components/Drawer/drawer.css";
 import "./BoxedExpressionEditor.css";
 import { I18nDictionariesProvider } from "@kogito-tooling/i18n/dist/react-components";
 import { ExpressionContainer, ExpressionContainerProps } from "../ExpressionContainer";
-import { ResizerSupervisor, hashfy } from "../Resizer";
+import { hashfy, ResizerSupervisor } from "../Resizer";
 import {
   boxedExpressionEditorDictionaries,
   BoxedExpressionEditorI18nContext,
@@ -29,10 +29,13 @@ import {
 } from "../../i18n";
 import { BoxedExpressionGlobalContext } from "../../context";
 import * as _ from "lodash";
+import { PMMLParams } from "../../api";
 
 export interface BoxedExpressionEditorProps {
   /** All expression properties used to define it */
   expressionDefinition: ExpressionContainerProps;
+  /** PMML parameters */
+  pmmlParams?: PMMLParams;
 }
 
 const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element = (
@@ -52,6 +55,7 @@ const BoxedExpressionEditor: (props: BoxedExpressionEditorProps) => JSX.Element 
       >
         <BoxedExpressionGlobalContext.Provider
           value={{
+            pmmlParams: props.pmmlParams,
             supervisorHash,
             setSupervisorHash,
             boxedExpressionEditorRef,

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/FunctionExpression.tsx
@@ -28,6 +28,8 @@ import {
   JavaFunctionProps,
   LiteralExpressionProps,
   LogicType,
+  PmmlFunctionProps,
+  PMMLLiteralExpressionProps,
   resetEntry,
   TableHeaderVisibility,
   TableOperation,
@@ -50,8 +52,6 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
     props.parametersWidth === undefined ? DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH : props.parametersWidth;
   const formalParameters = props.formalParameters === undefined ? [] : props.formalParameters;
   const functionKind = props.functionKind === undefined ? FunctionKind.Feel : props.functionKind;
-  const name = props.name === undefined ? DEFAULT_FIRST_PARAM_NAME : props.name;
-
   const [width, setWidth] = useState(parametersWidth);
 
   const { i18n } = useBoxedExpressionEditorI18n();
@@ -60,11 +60,21 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
 
   const [parameters, setParameters] = useState(formalParameters);
 
+  const name = useRef(props.name === undefined ? DEFAULT_FIRST_PARAM_NAME : props.name);
+  const dataType = useRef(props.dataType === undefined ? DataType.Undefined : props.dataType);
+
+  const document = useRef((props as PmmlFunctionProps).document);
+  const model = useRef((props as PmmlFunctionProps).model);
+
+  const editParametersPopoverAppendTo = useCallback(() => {
+    return () => boxedExpressionEditorRef.current!;
+  }, [boxedExpressionEditorRef]);
+
   const headerCellElement = useMemo(
     () => (
       <PopoverMenu
         title={i18n.editParameters}
-        appendTo={boxedExpressionEditorRef?.current ?? undefined}
+        appendTo={editParametersPopoverAppendTo()}
         className="parameters-editor-popover"
         minWidth="400px"
         body={<EditParameters parameters={parameters} setParameters={setParameters} />}
@@ -81,28 +91,29 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
         </div>
       </PopoverMenu>
     ),
-    [boxedExpressionEditorRef, i18n.editParameters, parameters]
+    [editParametersPopoverAppendTo, i18n.editParameters, parameters]
   );
 
   const evaluateColumns = useCallback(
-    () => [
-      {
-        label: name,
-        accessor: name,
-        dataType: props.dataType,
-        disableHandlerOnHeader: true,
-        columns: [
-          {
-            headerCellElement,
-            accessor: "parameters",
-            disableHandlerOnHeader: true,
-            width: width,
-            minWidth: DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
-          },
-        ],
-      },
-    ],
-    [name, props.dataType, headerCellElement, width]
+    () =>
+      [
+        {
+          label: name.current,
+          accessor: name.current,
+          dataType: dataType.current,
+          disableHandlerOnHeader: true,
+          columns: [
+            {
+              headerCellElement,
+              accessor: "parameters",
+              disableHandlerOnHeader: true,
+              width: width,
+              minWidth: DEFAULT_ENTRY_EXPRESSION_MIN_WIDTH,
+            },
+          ],
+        },
+      ] as ColumnInstance[],
+    [headerCellElement, width]
   );
 
   const extractContextEntriesFromJavaProps = useCallback(
@@ -129,9 +140,51 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
     [i18n.class, i18n.methodSignature]
   );
 
+  const extractContextEntriesFromPmmlProps = useCallback(
+    (pmmlProps: PmmlFunctionProps & { children?: React.ReactNode }) => {
+      return [
+        {
+          entryInfo: { name: i18n.document, dataType: DataType.String },
+          entryExpression: {
+            noClearAction: true,
+            logicType: LogicType.PMMLLiteralExpression,
+            noOptionsLabel: i18n.pmml.firstSelection,
+            getOptions: () => _.map(pmmlProps.pmmlParams, "document"),
+            selected: document.current,
+          } as PMMLLiteralExpressionProps,
+        },
+        {
+          entryInfo: { name: i18n.model, dataType: DataType.String },
+          entryExpression: {
+            noClearAction: true,
+            logicType: LogicType.PMMLLiteralExpression,
+            noOptionsLabel: i18n.pmml.secondSelection,
+            getOptions: () =>
+              _.map(
+                _.find(pmmlProps.pmmlParams, (param) => param.document === document.current)?.modelsFromDocument,
+                "model"
+              ),
+            selected: model.current,
+          } as PMMLLiteralExpressionProps,
+        },
+      ];
+    },
+    [i18n.document, i18n.model, i18n.pmml.firstSelection, i18n.pmml.secondSelection]
+  );
+
+  const extractParametersFromPmmlProps = useCallback(
+    (pmmlProps: PmmlFunctionProps & { children?: React.ReactNode }) => {
+      return (
+        _.find(_.find(pmmlProps.pmmlParams, { document: document.current })?.modelsFromDocument, {
+          model: model.current,
+        })?.parametersFromModel || []
+      );
+    },
+    []
+  );
+
   const evaluateRows = useCallback(
     (functionKind: FunctionKind) => {
-      //TODO PMML kind is still missing
       switch (functionKind) {
         case FunctionKind.Java: {
           const javaProps: PropsWithChildren<JavaFunctionProps> = props as PropsWithChildren<JavaFunctionProps>;
@@ -147,7 +200,20 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
             } as DataRecord,
           ];
         }
-        case FunctionKind.Pmml:
+        case FunctionKind.Pmml: {
+          const pmmlProps: PropsWithChildren<PmmlFunctionProps> = props as PropsWithChildren<PmmlFunctionProps>;
+          return [
+            {
+              entryExpression: {
+                logicType: LogicType.Context,
+                noClearAction: true,
+                renderResult: false,
+                noHandlerMenu: true,
+                contextEntries: extractContextEntriesFromPmmlProps(pmmlProps),
+              },
+            } as DataRecord,
+          ];
+        }
         case FunctionKind.Feel:
         default: {
           const feelProps: PropsWithChildren<FeelFunctionProps> = props as PropsWithChildren<FeelFunctionProps>;
@@ -157,16 +223,43 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
         }
       }
     },
-    [extractContextEntriesFromJavaProps, props]
+    [extractContextEntriesFromJavaProps, extractContextEntriesFromPmmlProps, props]
   );
 
   const columns = useRef(evaluateColumns());
   const [selectedFunctionKind, setSelectedFunctionKind] = useState(functionKind);
   const [rows, setRows] = useState(evaluateRows(selectedFunctionKind));
 
+  const retrieveModelValue = useCallback(
+    (documentValue: string, contextProps: ContextProps) =>
+      documentValue === document.current
+        ? _.includes(
+            (_.nth(contextProps.contextEntries, 1)?.entryExpression as PMMLLiteralExpressionProps)?.getOptions(),
+            (_.nth(contextProps.contextEntries, 1)?.entryExpression as PMMLLiteralExpressionProps)?.selected
+          )
+          ? (_.nth(contextProps.contextEntries, 1)?.entryExpression as PMMLLiteralExpressionProps)?.selected
+          : ""
+        : "",
+    []
+  );
+
+  const setParametersBasedOnDocumentAndModel = useCallback(
+    (documentHasBeenChanged: boolean, modelHasBeenChanged: boolean) => {
+      if (documentHasBeenChanged) {
+        setParameters([]);
+      }
+      if (modelHasBeenChanged) {
+        const parametersFromPmmlProps = extractParametersFromPmmlProps(props as PmmlFunctionProps);
+        if (!_.isEmpty(parametersFromPmmlProps)) {
+          setParameters(parametersFromPmmlProps);
+        }
+      }
+    },
+    [extractParametersFromPmmlProps, props]
+  );
+
   const extendDefinitionBasedOnFunctionKind = useCallback(
     (definition: FunctionProps, functionKind: FunctionKind) => {
-      //TODO PMML kind is still missing
       switch (functionKind) {
         case FunctionKind.Java: {
           const contextProps = _.first(rows)?.entryExpression as ContextProps;
@@ -176,14 +269,25 @@ export const FunctionExpression: React.FunctionComponent<FunctionProps> = (props
             (_.nth(contextProps.contextEntries, 1)?.entryExpression as LiteralExpressionProps)?.content || "";
           return _.extend(definition, { class: className, method: methodName });
         }
-        case FunctionKind.Pmml:
+        case FunctionKind.Pmml: {
+          const contextProps = _.first(rows)?.entryExpression as ContextProps;
+          const documentValue =
+            (_.nth(contextProps.contextEntries, 0)?.entryExpression as PMMLLiteralExpressionProps)?.selected || "";
+          const modelValue = retrieveModelValue(documentValue, contextProps);
+          const documentHasBeenChanged = documentValue !== document.current;
+          const modelHasBeenChanged = modelValue !== model.current;
+          document.current = documentValue;
+          model.current = modelValue;
+          setParametersBasedOnDocumentAndModel(documentHasBeenChanged, modelHasBeenChanged);
+          return _.extend(definition, { document: documentValue, model: modelValue });
+        }
         case FunctionKind.Feel:
         default: {
           return _.extend(definition, { expression: _.first(rows)?.entryExpression as ExpressionProps });
         }
       }
     },
-    [rows]
+    [retrieveModelValue, rows, setParametersBasedOnDocumentAndModel]
   );
 
   const spreadFunctionExpressionDefinition = useCallback(() => {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/PMMLLiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/PMMLLiteralExpression.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-export enum LogicType {
-  Undefined = "<Undefined>",
-  LiteralExpression = "Literal expression",
-  PMMLLiteralExpression = "PMML Literal expression",
-  Context = "Context",
-  DecisionTable = "Decision Table",
-  Relation = "Relation",
-  Function = "Function",
-  Invocation = "Invocation",
-  List = "List",
+.pmml-literal-expression.showing-placeholder .pf-c-select__toggle-text {
+  color: gray;
+  font-style: italic;
+  font-weight: var(--pf-global--FontWeight--normal);
+  padding-right: 0.125em;
 }

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/PMMLLiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/PMMLLiteralExpression.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "./PMMLLiteralExpression.css";
+import * as React from "react";
+import { useCallback, useContext, useRef, useState } from "react";
+import { PMMLLiteralExpressionProps } from "../../api";
+import { Select, SelectOption, SelectVariant } from "@patternfly/react-core";
+import * as _ from "lodash";
+import { BoxedExpressionGlobalContext } from "../../context";
+
+export const PMMLLiteralExpression: React.FunctionComponent<PMMLLiteralExpressionProps> = (
+  props: PMMLLiteralExpressionProps
+) => {
+  const globalContext = useContext(BoxedExpressionGlobalContext);
+
+  const selection = useRef(props.selected);
+
+  const [selectOpen, setSelectOpen] = useState(false);
+
+  const onSelectToggle = useCallback((isOpen) => setSelectOpen(isOpen), []);
+
+  const onSelect = useCallback(
+    (event, updatedSelection) => {
+      setSelectOpen(false);
+      selection.current = updatedSelection;
+      props.onUpdatingRecursiveExpression?.({
+        ...props,
+        selected: updatedSelection,
+      } as PMMLLiteralExpressionProps);
+    },
+    [props]
+  );
+
+  const getOptions = useCallback(() => {
+    return _.map(props.getOptions(), (key) => (
+      <SelectOption key={key} value={key} data-ouia-component-id={key}>
+        {key}
+      </SelectOption>
+    ));
+  }, [props]);
+
+  const getSelection = useCallback(() => {
+    return _.includes(props.getOptions(), selection.current) ? selection.current : undefined;
+  }, [props]);
+
+  const showingPlaceholder = useCallback(() => _.isEmpty(getSelection()), [getSelection]);
+
+  return (
+    <Select
+      className={`pmml-literal-expression ${showingPlaceholder() ? "showing-placeholder" : ""}`}
+      menuAppendTo={globalContext.boxedExpressionEditorRef?.current ?? "inline"}
+      ouiaId="pmml-literal-expression-selector"
+      placeholderText={props.noOptionsLabel}
+      aria-placeholder={props.noOptionsLabel}
+      variant={SelectVariant.single}
+      onToggle={onSelectToggle}
+      onSelect={onSelect}
+      isOpen={selectOpen}
+      selections={getSelection()}
+    >
+      {getOptions()}
+    </Select>
+  );
+};

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/index.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from "./LiteralExpression";
+export * from "./PMMLLiteralExpression";

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LogicTypeSelector/LogicTypeSelector.tsx
@@ -28,9 +28,10 @@ import {
   ListProps,
   LiteralExpressionProps,
   LogicType,
+  PMMLLiteralExpressionProps,
   RelationProps,
 } from "../../api";
-import { LiteralExpression } from "../LiteralExpression";
+import { LiteralExpression, PMMLLiteralExpression } from "../LiteralExpression";
 import { RelationExpression } from "../RelationExpression";
 import { ContextExpression } from "../ContextExpression";
 import { useBoxedExpressionEditorI18n } from "../../i18n";
@@ -103,6 +104,8 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
     switch (expression.logicType) {
       case LogicType.LiteralExpression:
         return <LiteralExpression {...(expression as LiteralExpressionProps)} />;
+      case LogicType.PMMLLiteralExpression:
+        return <PMMLLiteralExpression {...(expression as PMMLLiteralExpressionProps)} />;
       case LogicType.Relation:
         return <RelationExpression {...(expression as RelationProps)} />;
       case LogicType.Context:
@@ -122,19 +125,22 @@ export const LogicTypeSelector: React.FunctionComponent<LogicTypeSelectorProps> 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expression.logicType]);
 
-  const getLogicTypesWithoutUndefined = useCallback(
-    () => Object.values(LogicType).filter((logicType) => logicType !== LogicType.Undefined),
+  const getSelectableLogicTypes = useCallback(
+    () =>
+      Object.values(LogicType).filter(
+        (logicType) => !_.includes([LogicType.Undefined, LogicType.PMMLLiteralExpression], logicType)
+      ),
     []
   );
 
   const renderLogicTypeItems = useCallback(
     () =>
-      _.map(getLogicTypesWithoutUndefined(), (key) => (
+      _.map(getSelectableLogicTypes(), (key) => (
         <MenuItem key={key} itemId={key}>
           {key}
         </MenuItem>
       )),
-    [getLogicTypesWithoutUndefined]
+    [getSelectableLogicTypes]
   );
 
   const getArrowPlacement = useCallback(() => getPlacementRef() as HTMLElement, [getPlacementRef]);

--- a/kie-wb-common-react/boxed-expression-editor/src/context/BoxedExpressionGlobalContext.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/context/BoxedExpressionGlobalContext.tsx
@@ -15,8 +15,10 @@
  */
 
 import * as React from "react";
+import { PMMLParams } from "../api";
 
 export interface BoxedExpressionGlobalContextProps {
+  pmmlParams?: PMMLParams;
   supervisorHash: string;
   setSupervisorHash: (hash: string) => void;
   boxedExpressionEditorRef: React.RefObject<HTMLDivElement>;

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/BoxedExpressionEditorI18n.ts
@@ -32,6 +32,7 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpre
   contextEntry: string;
   dataType: string;
   decisionTable: string;
+  document: string;
   editContextEntry: string;
   editExpression: string;
   editParameter: string;
@@ -44,8 +45,13 @@ interface BoxedExpressionEditorDictionary extends ReferenceDictionary<BoxedExpre
   list: string;
   literalExpression: string;
   methodSignature: string;
+  model: string;
   name: string;
   parameters: string;
+  pmml: {
+    firstSelection: string;
+    secondSelection: string;
+  };
   relation: string;
   rows: string;
   rowOperations: {

--- a/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
+++ b/kie-wb-common-react/boxed-expression-editor/src/i18n/locales/en.ts
@@ -34,6 +34,7 @@ export const en: BoxedExpressionEditorI18n = {
   dataType: "Data Type",
   decisionTable: "Decision Table",
   delete: "Delete",
+  document: "document",
   editContextEntry: "Edit Context Entry",
   editExpression: "Edit Expression",
   editParameter: "Edit Parameter",
@@ -45,8 +46,13 @@ export const en: BoxedExpressionEditorI18n = {
   list: "List",
   literalExpression: "Literal expression",
   methodSignature: "method signature",
+  model: "model",
   name: "Name",
   parameters: "PARAMETERS",
+  pmml: {
+    firstSelection: "First select PMML document",
+    secondSelection: "Second select PMML model",
+  },
   relation: "Relation",
   rowOperations: {
     clear: "Clear",


### PR DESCRIPTION
This PR contains both KOGITO-3651 and KOGITO-3652.
In order to have PMML documents and models populated, you need to pass them as properties.
The TS type describes the format of expected `pmmlParams`, but you can also find below an example of expression with such populated fields.

<details>
<summary>You can change "showcase/index.tsx" in this way...</summary>

```javascript
/*
 * Copyright 2020 Red Hat, Inc. and/or its affiliates.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *        http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

import * as React from "react";
import { useState } from "react";
import * as ReactDOM from "react-dom";
import "./index.css";
// noinspection ES6PreferShortImport
import {
  BoxedExpressionEditor,
  ContextProps,
  DataType,
  ExpressionContainerProps,
  ExpressionProps,
  FunctionKind,
  FunctionProps,
  InvocationProps,
  ListProps,
  LiteralExpressionProps,
  LogicType,
  RelationProps,
} from "./boxed_expression_editor";

export const App: React.FunctionComponent = () => {
  //This definition comes directly from the decision node
  const selectedExpression: ExpressionProps = {
    name: "Expression Name",
    dataType: DataType.Undefined,
  };

  const [updatedExpression, setUpdatedExpression] = useState(selectedExpression);

  const mockedPMMLProps = {
    name: "Expression Name",
    dataType: DataType.Undefined,
    logicType: LogicType.Function,
    functionKind: FunctionKind.Pmml,
    pmmlParams: [
      {
        document: "mining pmml",
        modelsFromDocument: [
          {
            model: "MiningModelSum",
            parametersFromModel: [
              { name: "input1", dataType: DataType.Any },
              { name: "input2", dataType: DataType.Any },
              { name: "input3", dataType: DataType.Any },
            ],
          },
        ],
      },
      {
        document: "regression pmml",
        modelsFromDocument: [
          {
            model: "RegressionLinear",
            parametersFromModel: [
              { name: "i1", dataType: DataType.Number },
              { name: "i2", dataType: DataType.Number },
            ],
          },
        ],
      },
    ],
  };

  const expressionDefinition: ExpressionContainerProps = { selectedExpression: mockedPMMLProps };

  //Defining global function that will be available in the Window namespace and used by the BoxedExpressionEditor component
  window.beeApi = {
    resetExpressionDefinition: (definition: ExpressionProps) => setUpdatedExpression(definition),
    broadcastLiteralExpressionDefinition: (definition: LiteralExpressionProps) => setUpdatedExpression(definition),
    broadcastRelationExpressionDefinition: (definition: RelationProps) => setUpdatedExpression(definition),
    broadcastContextExpressionDefinition: (definition: ContextProps) => setUpdatedExpression(definition),
    broadcastListExpressionDefinition: (definition: ListProps) => setUpdatedExpression(definition),
    broadcastInvocationExpressionDefinition: (definition: InvocationProps) => setUpdatedExpression(definition),
    broadcastFunctionExpressionDefinition: (definition: FunctionProps) => setUpdatedExpression(definition),
  };

  return (
    <div className="showcase">
      <div className="boxed-expression">
        <BoxedExpressionEditor expressionDefinition={expressionDefinition} />
      </div>
      <div className="updated-json">
        <p className="disclaimer">
          ⚠ Currently, JSON gets updated only for literal expression, relation, context, list, invocation and function
          logic types
        </p>
        <pre>{JSON.stringify(updatedExpression, null, 2)}</pre>
      </div>
    </div>
  );
};

ReactDOM.render(<App />, document.getElementById("root"));

```
</details>  