### PR TITLE
Ignore .eslintcache

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/showcase/.gitignore
+++ b/kie-wb-common-react/boxed-expression-editor/showcase/.gitignore
@@ -1,0 +1,1 @@
+.eslintcache


### PR DESCRIPTION
Since I re-installed the macOS (hence whole setup) on my machine, this cache file keeps appearing.