### PR TITLE
KOGITO-4976/KOGITO-5202: [DMN Designer] New boxed expression editor - Support switching between read/edit mode on click / Styles are broken on Safari

### DIFF
--- a/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/BoxedExpressionEditor/BoxedExpressionEditor.css
@@ -21,6 +21,7 @@
   font-weight: var(--pf-global--FontWeight--normal);
   line-height: var(--pf-global--LineHeight--md);
   text-align: left;
+  user-select: none;
 }
 
 .boxed-expression-editor *,

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ExpressionContainer/ExpressionContainer.css
@@ -16,8 +16,8 @@
 
 .expression-container .expression-container-box {
   display: inline-block;
-  border-style: ridge;
-  border-color: #39A5DC;
+  border: 2px solid var(--pf-global--palette--black-300);
+  margin-top: 5px;
 }
 
 .expression-container .context-menu-container {

--- a/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/EditParameters.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/FunctionExpression/EditParameters.css
@@ -27,7 +27,7 @@
   height: 200px;
   overflow-y: scroll;
   margin-top: 10px;
-  border: 1px solid #cccccc;
+  border: 1px solid var(--pf-global--palette--black-300);
   padding: 0 5px 5px 5px;
 }
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/ListExpression/ListExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/ListExpression/ListExpression.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import {
   ContextEntryRecord,
+  DataType,
   ExpressionProps,
   ListProps,
   LiteralExpressionProps,
@@ -34,6 +35,7 @@ import { DataRecord, Row } from "react-table";
 import * as _ from "lodash";
 import { hashfy } from "../Resizer";
 import { BoxedExpressionGlobalContext } from "../../context";
+import nextId from "react-id-generator";
 
 const LIST_EXPRESSION_MIN_WIDTH = 430;
 
@@ -68,7 +70,14 @@ export const ListExpression: React.FunctionComponent<ListProps> = ({
   );
 
   const generateLiteralExpression = useCallback(
-    () => ({ logicType: LogicType.LiteralExpression } as LiteralExpressionProps),
+    () =>
+      ({
+        uid: nextId(),
+        name: "",
+        dataType: DataType.Undefined,
+        logicType: LogicType.LiteralExpression,
+        content: "",
+      } as LiteralExpressionProps),
     []
   );
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.css
@@ -28,6 +28,9 @@
 
 .expression-container .literal-expression {
   width: 100%;
+  color: var(--pf-global--Color--100);
+  background-color: var(--pf-global--BackgroundColor--100);
+  font-style: normal;
 }
 
 .literal-expression .literal-expression-header .expression-info {
@@ -45,7 +48,7 @@
   flex-wrap: wrap;
   position: relative;
   padding: 0.5em 0.1em 0.5em 0.5em;
-  border-style: ridge;
+  border: 1px solid var(--pf-global--palette--black-300);
   background-color: #def3ff;
   color: black;
 }
@@ -57,11 +60,10 @@
 .literal-expression .literal-expression-body {
   height: 4em;
   width: 100%;
-  border: 1px solid #eaeaea;
+  border: 1px solid var(--pf-global--palette--black-300);
 }
 
 .literal-expression .literal-expression-body textarea {
-  border-style: groove;
   font-style: normal;
   padding: 0.5em 0.5em 0 0.5em;
   width: 100%;

--- a/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/LiteralExpression/LiteralExpression.tsx
@@ -21,6 +21,7 @@ import { DataType, ExpressionProps, LiteralExpressionProps, LogicType } from "..
 import { TextArea } from "@patternfly/react-core";
 import { EditExpressionMenu, EXPRESSION_NAME } from "../EditExpressionMenu";
 import { Resizer } from "../Resizer";
+import { EditableCell } from "../Table";
 
 export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> = ({
   uid,
@@ -66,8 +67,8 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
   );
 
   const onContentChange = useCallback(
-    (event) => {
-      literalExpressionContent.current = event.target.value;
+    (value: string) => {
+      literalExpressionContent.current = value;
       spreadLiteralExpressionDefinition();
     },
     [spreadLiteralExpressionDefinition]
@@ -115,10 +116,11 @@ export const LiteralExpression: React.FunctionComponent<LiteralExpressionProps> 
 
   const getBodyContent = useMemo(
     () => (
-      <TextArea
-        defaultValue={literalExpressionContent.current}
-        onBlur={onContentChange}
-        aria-label="literal-expression-content"
+      <EditableCell
+        value={literalExpressionContent.current}
+        row={{ index: 0 }}
+        column={{ id: uid ?? "-" }}
+        onCellUpdate={(_number, _columnId, value) => onContentChange(value)}
       />
     ),
     [onContentChange]

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/Resizer.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Resizer/Resizer.css
@@ -24,11 +24,6 @@
   position: relative;
 }
 
-.expression-container .pf-c-drawer {
-  opacity: 0.3;
-  width: 5px;
-}
-
 .expression-container .pf-c-drawer__splitter::after {
   border: none;
 }
@@ -38,6 +33,7 @@
   position: absolute;
   left: -1px;
   top: 50%;
+  border-color: var(--pf-global--palette--black-300);
   transform: translateY(-50%);
 }
 

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/EditableCell.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/EditableCell.css
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.expression-container .editable-cell {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: default;
+  user-select: none;
+  overflow: hidden;
+  position: relative;
+}
+
+.expression-container .editable-cell:active,
+.expression-container .editable-cell.editable-cell--selected {
+  border: 2px solid #438cb1;
+}
+
+.expression-container .editable-cell span,
+.expression-container .editable-cell textarea {
+  width: 100%;
+}
+
+.expression-container .editable-cell span {
+  padding: 0 5px;
+  white-space: pre-line;
+}
+
+.expression-container .editable-cell textarea {
+  padding: 0 4px;
+}
+
+.expression-container .editable-cell.editable-cell--edit-mode span,
+.expression-container .editable-cell.editable-cell--read-mode textarea {
+  position: absolute;
+  top: -100%;
+  left: -100%;
+}
+
+.expression-container .editable-cell span {
+  display: inline-block;
+  vertical-align: middle;
+  line-height: normal;
+}

--- a/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
+++ b/kie-wb-common-react/boxed-expression-editor/src/components/Table/Table.css
@@ -86,7 +86,7 @@
 
 .expression-container .table-component table thead th,
 .expression-container .table-component table tbody td {
-  border: 1px solid #ccc;
+  border: 1px solid var(--pf-global--palette--black-300);
 }
 
 /** Table Body rules */
@@ -97,7 +97,7 @@
 }
 
 .expression-container .table-component table tbody td {
-  border-style: ridge;
+  border-style: solid;
   padding: 1.1em 0;
   text-align: center;
   overflow: hidden;
@@ -160,12 +160,8 @@
 /** Text-area used as a cell */
 
 .expression-container .table-component table tbody td textarea {
-  padding: 0.125em;
-  margin: 0;
-  border: 0;
-  width: 100%;
-  height: 100%;
   resize: none;
+  border: none;
 }
 
 /** Row-remainder section */


### PR DESCRIPTION
[KOGITO-4976](https://issues.redhat.com/browse/KOGITO-4976): [DMN Designer] New boxed expression editor - Support switching between read/edit mode on click

[KOGITO-5202](https://issues.redhat.com/browse/KOGITO-5202): [DMN Designer] New boxed expression editor - Styles are broken on Safari

Here's the live demo: [karreiro.com/kogito-editors-java](https://karreiro.com/kogito-editors-java/)

---

**[DMN Designer] New boxed expression editor - Support switching between read/edit mode on click**

![Kapture 2021-05-25 at 16 26 17](https://user-images.githubusercontent.com/1079279/119634980-8762fe80-be13-11eb-8b6f-59b4ab3d3d18.gif)


**[DMN Designer] New boxed expression editor - Styles are broken on Safari**

![Kapture 2021-05-26 at 11 07 30](https://user-images.githubusercontent.com/1079279/119635004-8cc04900-be13-11eb-8a5a-232ff7c08aa5.gif)





